### PR TITLE
feat:added the primaryColor attribute for AnyHeader

### DIFF
--- a/harmony/smart_refresh_layout/src/main/cpp/HeaderNodeDelegate.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/HeaderNodeDelegate.h
@@ -16,5 +16,6 @@ namespace rnoh {
         virtual void onRefreshStatusChange(int32_t status){};
         virtual void addHeader(int32_t screenWidth, int32_t index, ArkUINode *arkUI_Node){};
         virtual void onHeaderMove(float dur){};
+        virtual facebook::react::SharedColor GetPrimaryColor(){};
     };
 } // namespace rnoh

--- a/harmony/smart_refresh_layout/src/main/cpp/Props.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/Props.h
@@ -22,6 +22,7 @@
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/graphics/Color.h>
+#include <string>
 
 namespace facebook {
 namespace react {
@@ -33,7 +34,7 @@ class JSI_EXPORT RNCAnyHeaderProps final : public ViewProps {
 
 #pragma mark - Props
 
-  std::string primaryColor{};
+  std::string primaryColor{""};
 };
 
 class JSI_EXPORT RNCClassicsHeaderProps final : public ViewProps {
@@ -54,8 +55,8 @@ class JSI_EXPORT RNCDefaultHeaderProps final : public ViewProps {
 
 #pragma mark - Props
 
-  SharedColor primaryColor{};
-  SharedColor accentColor{};
+  std::string primaryColor{};
+  std::string accentColor{};
 };
 
 class JSI_EXPORT RNCMaterialHeaderProps final : public ViewProps {
@@ -114,11 +115,11 @@ class JSI_EXPORT RNCStoreHouseHeaderProps final : public ViewProps {
 
 #pragma mark - Props
 
-  std::string textColor{};
-  std::string text{};
+  std::string textColor{"#cccccc"};
+  std::string text{"StoreHouse"};
   int fontSize{25};
-  Float lineWidth{0.0};
-  Float dropHeight{0.0};
+  Float lineWidth{1};
+  Float dropHeight{40};
 };
 
 } // namespace react

--- a/harmony/smart_refresh_layout/src/main/cpp/PullToRefreshNode.cpp
+++ b/harmony/smart_refresh_layout/src/main/cpp/PullToRefreshNode.cpp
@@ -49,6 +49,7 @@ namespace rnoh {
 
     void PullToRefreshNode::setEnableRefresh(bool enable) { refreshConfigurator.setHasRefresh(enable); }
     void PullToRefreshNode::setMaxTranslate(float maxHeight) { refreshConfigurator.setMaxTranslate(maxHeight); }
+    void PullToRefreshNode::setSensitivity(float setSensitivity) { refreshConfigurator.setSensitivity(setSensitivity); }
     void PullToRefreshNode::setHeaderBackgroundColor(facebook::react::SharedColor const &color) {
         uint32_t colorValue1 = *color;
         ArkUI_NumberValue preparedColorValue1[] = {{.u32 = colorValue1}};

--- a/harmony/smart_refresh_layout/src/main/cpp/PullToRefreshNode.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/PullToRefreshNode.h
@@ -43,6 +43,7 @@ namespace rnoh {
         void setHeaderBackgroundColor(facebook::react::SharedColor const &color);
         PullToRefreshConfigurator getPullToRefreshConfigurator() { return refreshConfigurator; }
         void onNodeEvent(ArkUI_NodeEventType eventType, EventArgs &eventArgs) override;
+        void setSensitivity(float setSensitivity);
     };
 
 } // namespace rnoh

--- a/harmony/smart_refresh_layout/src/main/cpp/RNCAnyHeaderComponentInstance.cpp
+++ b/harmony/smart_refresh_layout/src/main/cpp/RNCAnyHeaderComponentInstance.cpp
@@ -1,5 +1,6 @@
 #include "RNCAnyHeaderComponentInstance.h"
 #include "RNOH/arkui/NativeNodeApi.h"
+#include "SmartUtils.h"
 
 namespace rnoh {
 
@@ -38,10 +39,22 @@ namespace rnoh {
         if (rnInstancePtr != nullptr) {
             auto turboModule = rnInstancePtr->getTurboModule("RNCSmartRefreshContext");
             auto arkTsTurboModule = std::dynamic_pointer_cast<rnoh::ArkTSTurboModule>(turboModule);
-            folly::dynamic result = arkTsTurboModule->callSync("cvp2px", {getLayoutMetrics().frame.size.width});;
+            folly::dynamic result = arkTsTurboModule->callSync("cvp2px", {getLayoutMetrics().frame.size.width});
             folly::dynamic result1 = arkTsTurboModule->callSync("cvp2px", {childHeight});
             m_stackNode.setLayoutRect({0, 0}, {result["values"].asDouble(), result1["values"].asDouble()}, 1.0);
         }
+    }
+
+    void RNCAnyHeaderComponentInstance::onPropsChanged(SharedConcreteProps const &props) {
+        CppComponentInstance::onPropsChanged(props);
+        if (props == nullptr) {
+            return;
+        }
+        backColor = props->primaryColor;
+    }
+
+    facebook::react::SharedColor RNCAnyHeaderComponentInstance::GetPrimaryColor() {
+        return SmartUtils::parseColor(backColor);
     }
 
 } // namespace rnoh

--- a/harmony/smart_refresh_layout/src/main/cpp/RNCAnyHeaderComponentInstance.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/RNCAnyHeaderComponentInstance.h
@@ -1,21 +1,25 @@
 #pragma once
+#include "HeaderNodeDelegate.h"
 #include "RNOH/CppComponentInstance.h"
 #include "ShadowNodes.h"
 #include "SmartStackNode.h"
+#include <string>
 
 namespace rnoh {
-    class RNCAnyHeaderComponentInstance : public CppComponentInstance<facebook::react::RNCAnyHeaderShadowNode>  {
-    private:
-        SmartStackNode m_stackNode;
+class RNCAnyHeaderComponentInstance : public CppComponentInstance<facebook::react::RNCAnyHeaderShadowNode>,
+                                      public HeaderNodeDelegate {
+private:
+    SmartStackNode m_stackNode;
+    std::string backColor{""};
 
-    public:
-        RNCAnyHeaderComponentInstance(Context context);
+public:
+    RNCAnyHeaderComponentInstance(Context context);
 
-        void onChildInserted(ComponentInstance::Shared const &childComponentInstance, std::size_t index) override;
-        void onChildRemoved(ComponentInstance::Shared const &childComponentInstance) override;
-
-        SmartStackNode &getLocalRootArkUINode() override;
-        
-         void finalizeUpdates() override;
-    };
+    void onChildInserted(ComponentInstance::Shared const &childComponentInstance, std::size_t index) override;
+    void onChildRemoved(ComponentInstance::Shared const &childComponentInstance) override;
+    void onPropsChanged(SharedConcreteProps const &props) override;
+    SmartStackNode &getLocalRootArkUINode() override;
+    facebook::react::SharedColor GetPrimaryColor() override;
+    void finalizeUpdates() override;
+};
 } // namespace rnoh

--- a/harmony/smart_refresh_layout/src/main/cpp/RNCAnyHeaderJSIBinder.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/RNCAnyHeaderJSIBinder.h
@@ -31,7 +31,7 @@ protected:
 
     facebook::jsi::Object createNativeProps(facebook::jsi::Runtime &rt) override {
         auto nativeProps = ViewComponentJSIBinder::createNativeProps(rt);
-        nativeProps.setProperty(rt, "primaryColor", "number");
+        nativeProps.setProperty(rt, "primaryColor", "string");
         return nativeProps;
     }
 };

--- a/harmony/smart_refresh_layout/src/main/cpp/SmartRefreshLayoutComponentInstance.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/SmartRefreshLayoutComponentInstance.h
@@ -29,7 +29,7 @@ namespace rnoh {
         bool pureScroll{false};
         facebook::react::Float dragRate{0.5};
         facebook::react::Float maxDragRate{2.0};
-        facebook::react::SharedColor primaryColor{};
+        facebook::react::SharedColor mHeaderBackgroundColor{};
         facebook::react::SmartRefreshLayoutAutoRefreshStruct autoRefresh{};
         bool isHeaderInserted{false}; // whether list child component inserted
         float trYTop{0.0};

--- a/harmony/smart_refresh_layout/src/main/cpp/SmartUtils.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/SmartUtils.h
@@ -1,0 +1,34 @@
+//
+// Created on 10/3/2024.
+//
+// Node APIs are not fully supported. To solve the compilation error of the interface cannot be found,
+// please include "napi/native_api.h".
+
+#ifndef HARMONY_ANIMATION_H
+#define HARMONY_ANIMATION_H
+#include <string>
+#include <react/renderer/graphics/Color.h>
+
+class SmartUtils {
+public:
+    static facebook::react::SharedColor parseColor(std::string backColor) {
+        if (backColor != "" && backColor.find("#") != std::string::npos) {
+            backColor = backColor.substr(1);
+        }
+        if (backColor == "") {
+            return -1;
+        }
+        int num = std::stoi(backColor, NULL, 16);
+        float alpha = (num >> 24 & 0xff) / 255.0;
+        float red = (num >> 16 & 0xFF) / 255.0;
+        // 移位8个字节位，并执行&操作，可以得出green部件的数值
+        float green = (num >> 8 & 0xFF) / 255.0;
+        // 低位8个字节执行&操作，可以得出blue部件的数值
+        float blue = (num & 0xFF) / 255.0;
+        if (backColor.length() == 6) {
+            alpha = 1;
+        }
+        return facebook::react::colorFromComponents({red, green, blue, alpha});
+    }
+};
+#endif // HARMONY_ANIMATION_H


### PR DESCRIPTION
# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 新增AnyHeader的primaryColor 属性的实现
- Close: #29 

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

