### PR TITLE
feat:added the primaryColor and accentColor attribute for ClassicsHeader

### DIFF
--- a/harmony/smart_refresh_layout/src/main/cpp/RNCClassicsHeaderComponentInstance.cpp
+++ b/harmony/smart_refresh_layout/src/main/cpp/RNCClassicsHeaderComponentInstance.cpp
@@ -8,6 +8,7 @@
 #include "RNOH/arkui/NativeNodeApi.h"
 #include "react/renderer/imagemanager/primitives.h"
 #include "SmartRefreshState.h"
+#include "SmartUtils.h"
 
 namespace rnoh {
 
@@ -79,6 +80,19 @@ namespace rnoh {
     SmartStackNode &RNCClassicsHeaderComponentInstance::getLocalRootArkUINode() { return m_stackNode; }
 
     void RNCClassicsHeaderComponentInstance::onPropsChanged(SharedConcreteProps const &props) {
+        if (props != nullptr) {
+            primaryColor = props->primaryColor;
+            if (props->accentColor != "") {
+                textNode.setFontColor(SmartUtils::parseColor(props->accentColor));
+                timeTextNode.setFontColor(SmartUtils::parseColor(props->accentColor));
+                imageNode.setTintColor(SmartUtils::parseColor(props->accentColor));
+                updateImageNode.setTintColor(SmartUtils::parseColor(props->accentColor));
+            }
+        }
+    }
+
+    facebook::react::SharedColor RNCClassicsHeaderComponentInstance::GetPrimaryColor() {
+        return SmartUtils::parseColor(primaryColor);
     }
 
     void RNCClassicsHeaderComponentInstance::finalizeUpdates() {

--- a/harmony/smart_refresh_layout/src/main/cpp/RNCClassicsHeaderComponentInstance.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/RNCClassicsHeaderComponentInstance.h
@@ -38,5 +38,6 @@ namespace rnoh {
         std::string getDefaultHeaderBackGroundColor() { return primaryColor; }
         void setImageRotate(float angle);
         void setRotateAnimate(float angle, int32_t dur, int32_t count);
+        facebook::react::SharedColor GetPrimaryColor() override;
     };
 } // namespace rnoh

--- a/harmony/smart_refresh_layout/src/main/cpp/SmartTextNode.cpp
+++ b/harmony/smart_refresh_layout/src/main/cpp/SmartTextNode.cpp
@@ -27,10 +27,11 @@ SmartTextNode &SmartTextNode::setTextContent(const std::string &text) {
     return *this;
 }
 
-SmartTextNode &SmartTextNode::setFontColor(uint32_t color) {
-    ArkUI_NumberValue value[] = {{.u32 = color}};
-    ArkUI_AttributeItem item = {.value = value, .size = 1};
-    maybeThrow(NativeNodeApi::getInstance()->setAttribute(m_nodeHandle, NODE_FONT_COLOR, &item));
+SmartTextNode &SmartTextNode::setFontColor(facebook::react::SharedColor const &color) {
+    uint32_t colorValue = *color;
+    ArkUI_NumberValue preparedColorValue[] = {{.u32 = colorValue}};
+    ArkUI_AttributeItem colorItem = {preparedColorValue, sizeof(preparedColorValue) / sizeof(ArkUI_NumberValue)};
+    maybeThrow(NativeNodeApi::getInstance()->setAttribute(m_nodeHandle, NODE_FONT_COLOR, &colorItem));
     return *this;
 }
 

--- a/harmony/smart_refresh_layout/src/main/cpp/SmartTextNode.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/SmartTextNode.h
@@ -36,7 +36,7 @@ class SmartTextNode : public ArkUINode {
   void removeChild(ArkUINode& child);
 
   SmartTextNode& setTextContent(const std::string& text);
-  SmartTextNode& setFontColor(uint32_t fontColor);
+  SmartTextNode& setFontColor(facebook::react::SharedColor const& color);
   SmartTextNode& setFontSize(float fontSize);
 };
 } // namespace rnoh


### PR DESCRIPTION
# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 新增ClassicsHeader头部的primaryColor、 accentColor属性
- Close: #32 

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

