### PR TITLE
feat:added the primaryColor and accentColor attribute for DefaultHeader

### DIFF
--- a/harmony/smart_refresh_layout/src/main/cpp/RNCDefaultHeaderComponentInstance.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/RNCDefaultHeaderComponentInstance.h
@@ -24,6 +24,7 @@ namespace rnoh {
         SmartProgressNode progressNode;
         ArkUI_NodeHandle mColumnHandle;
         std::string primaryColor{""};
+        std::string accentColor{""};
 
     public:
         RNCDefaultHeaderComponentInstance(Context context);
@@ -34,7 +35,7 @@ namespace rnoh {
         void finalizeUpdates() override;
         SmartStackNode &getLocalRootArkUINode() override;
         void onRefreshStatusChange(int32_t status) override;
-        std::string getDefaultHeaderBackGroundColor() { return primaryColor; }
         void setImageRotate(float angle);
+        facebook::react::SharedColor GetPrimaryColor() override;
     };
 } // namespace rnoh


### PR DESCRIPTION
# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 新增DefaultHeader头部的primaryColor 、 accentColor属性
- Close: #34 

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

