### PR TITLE
fix:fix materialHeader The header icon is not centered

### DIFF
--- a/harmony/smart_refresh_layout/src/main/cpp/RNCMaterialHeaderComponentInstance.cpp
+++ b/harmony/smart_refresh_layout/src/main/cpp/RNCMaterialHeaderComponentInstance.cpp
@@ -24,48 +24,45 @@ namespace rnoh {
     
         ArkUI_NumberValue heightArray[] = {{.f32 = 45}};
         ArkUI_AttributeItem heightValue[] = {heightArray, 1};
-        NativeNodeApi::getInstance()->setAttribute(imageStack, NODE_HEIGHT, heightValue);
+        NativeNodeApi::getInstance()->setAttribute(imageStack.getArkUINodeHandle(), NODE_HEIGHT, heightValue);
         ArkUI_NumberValue widthArray[] = {{.f32 = 45}};
         ArkUI_AttributeItem widthValue[] = {widthArray, 1};
-        NativeNodeApi::getInstance()->setAttribute(imageStack, NODE_WIDTH, widthValue);
-    
-        ArkUI_NumberValue borderStyArray[] = {1};
+        NativeNodeApi::getInstance()->setAttribute(imageStack.getArkUINodeHandle(), NODE_WIDTH, widthValue);
+
+        ArkUI_NumberValue borderStyArray[] = {0.2};
         ArkUI_AttributeItem borderStyValue[] = {borderStyArray, 1};
-        NativeNodeApi::getInstance()->setAttribute(imageStack, NODE_BORDER_WIDTH, borderStyValue);
+        NativeNodeApi::getInstance()->setAttribute(imageStack.getArkUINodeHandle(), NODE_BORDER_WIDTH, borderStyValue);
 
         ArkUI_NumberValue radiusArray[] = {{.f32 = 45}};
         ArkUI_AttributeItem radiusValue[] = {radiusArray, 1};
-        NativeNodeApi::getInstance()->setAttribute(imageStack, NODE_BORDER_RADIUS, radiusValue);
-
+        NativeNodeApi::getInstance()->setAttribute(imageStack.getArkUINodeHandle(), NODE_BORDER_RADIUS, radiusValue);
+        imageStack.setBackgroundColor(0xFFfafafa);
         ArkUI_NumberValue borderColorArray[] = {
             {.u32 = 0xFFaaaaaa}, {.u32 = 0xFFaaaaaa}, {.u32 = 0xFFaaaaaa}, {.u32 = 0xFFaaaaaa}, {.u32 = 0xFFaaaaaa}};
         ArkUI_AttributeItem borderColorValue[] = {borderColorArray, 4};
-        NativeNodeApi::getInstance()->setAttribute(imageStack, NODE_BORDER_COLOR, borderColorValue);
+        NativeNodeApi::getInstance()->setAttribute(imageStack.getArkUINodeHandle(), NODE_BORDER_COLOR,
+                                                   borderColorValue);
 
         uint32_t shadowColorValue = 0xffaaaaaa;
-        uint32_t alpha = static_cast<uint32_t>((float)(shadowColorValue >> 24 & (0xff))*1.0);
+        uint32_t alpha = static_cast<uint32_t>((float)(shadowColorValue >> 24 & (0xff)) * 1.0);
         shadowColorValue = (alpha << 24) + (shadowColorValue & 0xffffff);
-         ArkUI_NumberValue shadowValue[] = {
-            {.f32 = 2}, 
-            {.i32 = 0}, 
-            {.f32 = 1}, 
-            {.f32 = 1}, 
-            {.i32 = 0},
-            {.u32 = shadowColorValue},
-            {.u32 = 0}
-         };
-        ArkUI_AttributeItem shadowItem = {.value = shadowValue,.size = sizeof(shadowValue)/sizeof(ArkUI_NumberValue)};
-        NativeNodeApi::getInstance()->setAttribute(imageStack, NODE_CUSTOM_SHADOW, &shadowItem);
-    
+        ArkUI_NumberValue shadowValue[] = {
+            {.f32 = 2}, {.i32 = 0}, {.f32 = 1}, {.f32 = 1}, {.i32 = 0}, {.u32 = shadowColorValue}, {.u32 = 0}};
+        ArkUI_AttributeItem shadowItem = {.value = shadowValue,
+                                          .size = sizeof(shadowValue) / sizeof(ArkUI_NumberValue)};
+        NativeNodeApi::getInstance()->setAttribute(imageStack.getArkUINodeHandle(), NODE_CUSTOM_SHADOW, &shadowItem);
+
         ArkUI_NumberValue z_indexArray[] = {{.f32 = 1000}};
         ArkUI_AttributeItem z_indexValue[] = {z_indexArray, 1};
-        NativeNodeApi::getInstance()->setAttribute(imageStack, NODE_Z_INDEX, z_indexValue);
+        NativeNodeApi::getInstance()->setAttribute(imageStack.getArkUINodeHandle(), NODE_Z_INDEX, z_indexValue);
 
-        NativeNodeApi::getInstance()->insertChildAt(imageStack, progressNode.getArkUINodeHandle(), 0);
-        NativeNodeApi::getInstance()->insertChildAt(arkUI_Node->getArkUINodeHandle(), imageStack, index);
+        NativeNodeApi::getInstance()->insertChildAt(imageStack.getArkUINodeHandle(), progressNode.getArkUINodeHandle(),
+                                                    0);
+        NativeNodeApi::getInstance()->insertChildAt(arkUI_Node->getArkUINodeHandle(), imageStack.getArkUINodeHandle(),
+                                                    index);
         ArkUI_NumberValue positionArray[] = {{.f32 = static_cast<float>((screenWidth - 46) / 2.0)}, {.f32 = -46}};
         ArkUI_AttributeItem positionValue[] = {positionArray, 2};
-        NativeNodeApi::getInstance()->setAttribute(imageStack, NODE_POSITION, positionValue);
+        NativeNodeApi::getInstance()->setAttribute(imageStack.getArkUINodeHandle(), NODE_POSITION, positionValue);
     }
 
     void RNCMaterialHeaderComponentInstance::onHeaderMove(float dur) {
@@ -74,7 +71,7 @@ namespace rnoh {
         }
         ArkUI_NumberValue positionArray[] = {{.f32 = static_cast<float>((mWindowWidth - 46) / 2.0)}, {.f32 = dur - 46}};
         ArkUI_AttributeItem positionValue[] = {positionArray, 2};
-        NativeNodeApi::getInstance()->setAttribute(imageStack, NODE_POSITION, positionValue);
+        NativeNodeApi::getInstance()->setAttribute(imageStack.getArkUINodeHandle(), NODE_POSITION, positionValue);
     }
     void RNCMaterialHeaderComponentInstance::setScaleAnimate(int32_t dur) {
 
@@ -83,15 +80,30 @@ namespace rnoh {
             float value = 1.0 - static_cast<float>(v);
             ArkUI_NumberValue scaleArray[] = {{.f32 = value}, {.f32 = value}};
             ArkUI_AttributeItem scaleValue[] = {scaleArray, 2};
-            NativeNodeApi::getInstance()->setAttribute(imageStack, NODE_SCALE, scaleValue);
+            NativeNodeApi::getInstance()->setAttribute(imageStack.getArkUINodeHandle(), NODE_SCALE, scaleValue);
             if (std::abs(value - 0.01) < 1e-6) {
                 ArkUI_NumberValue scaleArray[] = {{.f32 = 1.0}, {.f32 = 1.0}};
                 ArkUI_AttributeItem scaleValue[] = {scaleArray, 2};
-                NativeNodeApi::getInstance()->setAttribute(imageStack, NODE_SCALE, scaleValue);
+                NativeNodeApi::getInstance()->setAttribute(imageStack.getArkUINodeHandle(), NODE_SCALE, scaleValue);
             }
         });
         task->execute();
     }
+
+    void RNCMaterialHeaderComponentInstance::finalizeUpdates() {
+        auto rnInstancePtr = this->m_deps->rnInstance.lock();
+        if (rnInstancePtr != nullptr) {
+            auto turboModule = rnInstancePtr->getTurboModule("RNCSmartRefreshContext");
+            auto arkTsTurboModule = std::dynamic_pointer_cast<rnoh::ArkTSTurboModule>(turboModule);
+            folly::dynamic result = arkTsTurboModule->callSync("cvp2px", {getLayoutMetrics().frame.size.width});
+            folly::dynamic result1 = arkTsTurboModule->callSync("cvp2px", {60});
+            m_stackNode.setLayoutRect({0, 0}, {result["values"].asDouble(), result1["values"].asDouble()}, 1.0);
+        }
+        m_stackNode.setAlignment(ARKUI_ALIGNMENT_BOTTOM);
+    }
+
+    facebook::react::SharedColor RNCMaterialHeaderComponentInstance::GetPrimaryColor() { return -1; }
+
     void RNCMaterialHeaderComponentInstance::onChildInserted(ComponentInstance::Shared const &childComponentInstance,
                                                              std::size_t index) {
         CppComponentInstance::onChildInserted(childComponentInstance, index);
@@ -115,7 +127,7 @@ namespace rnoh {
             float y = -46.0;
             ArkUI_NumberValue positionArray[] = {{.f32 = x}, {.f32 = y}};
             ArkUI_AttributeItem positionValue[] = {positionArray, 2};
-            NativeNodeApi::getInstance()->setAttribute(imageStack, NODE_POSITION, positionValue);
+            NativeNodeApi::getInstance()->setAttribute(imageStack.getArkUINodeHandle(), NODE_POSITION, positionValue);
         }
         case IS_PULL_DOWN_1:
         case IS_PULL_DOWN_2: {

--- a/harmony/smart_refresh_layout/src/main/cpp/RNCMaterialHeaderComponentInstance.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/RNCMaterialHeaderComponentInstance.h
@@ -17,7 +17,7 @@ namespace rnoh {
 
     private:
         SmartStackNode m_stackNode;
-        ArkUI_NodeHandle imageStack{m_stackNode.getArkUINodeHandle()};
+        SmartStackNode imageStack;
         SmartProgressNode progressNode;
         float mWindowWidth{0.0};
         bool isRefreshed{false};
@@ -32,5 +32,7 @@ namespace rnoh {
         void addHeader(int32_t screenWidth, int32_t index, ArkUINode *arkUI_Node) override;
         void onHeaderMove(float dur) override;
         void setScaleAnimate(int32_t dur);
+        facebook::react::SharedColor GetPrimaryColor() override;
+        void finalizeUpdates() override;
     };
 } // namespace rnoh

--- a/harmony/smart_refresh_layout/src/main/cpp/SmartProgressNode.cpp
+++ b/harmony/smart_refresh_layout/src/main/cpp/SmartProgressNode.cpp
@@ -20,14 +20,15 @@ void SmartProgressNode::setLoadingProgressNodeColor(facebook::react::SharedColor
 }
 
 void SmartProgressNode::setLoadingProgressNodeAnimating(const bool &enable) {
-    uint32_t typeValue = 1;
-    if (!enable) {
-        typeValue = 0;
-    }
-    ArkUI_NumberValue preparedTypeValue[] = {{.u32 = typeValue}};
-    ArkUI_AttributeItem typeItem = {preparedTypeValue, sizeof(preparedTypeValue) / sizeof(ArkUI_NumberValue)};
-    maybeThrow(
-        NativeNodeApi::getInstance()->setAttribute(m_nodeHandle, NODE_LOADING_PROGRESS_ENABLE_LOADING, &typeItem));
+    uint32_t enableLoadingProgressNodeAnimation = enable ? 1 : 0;
+    std::array<ArkUI_NumberValue, 1> enableLoadingProgressNodeAnimationValue = {
+        {{.u32 = enableLoadingProgressNodeAnimation}}};
+
+    ArkUI_AttributeItem enableLoadingProgressNodeAnimationItem = {enableLoadingProgressNodeAnimationValue.data(),
+                                                                  enableLoadingProgressNodeAnimationValue.size()};
+
+    maybeThrow(NativeNodeApi::getInstance()->setAttribute(m_nodeHandle, NODE_LOADING_PROGRESS_ENABLE_LOADING,
+                                                          &enableLoadingProgressNodeAnimationItem));
 }
 
 } // namespace rnoh


### PR DESCRIPTION
# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 修复materialHeader 的图标不居中
- Close: #36 

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

