### PR TITLE
feat:new StoreHouseHeader header for SmartRefreshLayout

### DIFF
--- a/harmony/smart_refresh_layout/src/main/cpp/RNCStoreHouseBarItem.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/RNCStoreHouseBarItem.h
@@ -1,0 +1,75 @@
+//
+// Created on 2024/7/7.
+//
+// Node APIs are not fully supported. To solve the compilation error of the interface cannot be found,
+// please include "napi/native_api.h".
+
+#ifndef HARMONY_RNCSTOREHOUSEBARITEM_H
+#define HARMONY_RNCSTOREHOUSEBARITEM_H
+#include <cstdlib>
+#include <ctime>
+#include <native_drawing/drawing_canvas.h>
+#include <native_drawing/drawing_pen.h>
+#include <native_drawing/drawing_types.h>
+#include <react/renderer/graphics/Color.h>
+#include <glog/logging.h>
+namespace rnoh {
+
+typedef struct {
+    float x;
+    float y;
+} PointF;
+
+
+class RNCStoreHouseBarItem {
+
+public:
+    ~RNCStoreHouseBarItem() { OH_Drawing_PenDestroy(mPaint); }
+    RNCStoreHouseBarItem(int i, PointF start, PointF end, facebook::react::SharedColor color, int lineWidth) {
+        index = i;
+        midPoint = {(start.x + end.x) / 2, (start.y + end.y) / 2};
+
+        mCStartPoint = {start.x - midPoint.x, start.y - midPoint.y};
+        mCEndPoint = {end.x - midPoint.x, end.y - midPoint.y};
+
+        setColor(color);
+        setLineWidth(lineWidth);
+        OH_Drawing_PenSetAntiAlias(mPaint, true);
+    }
+    void setColor(facebook::react::SharedColor color) { OH_Drawing_PenSetColor(mPaint, *color); }
+    void setLineWidth(int lineWidth) { OH_Drawing_PenSetWidth(mPaint, lineWidth); }
+
+    void applyTransformation(float interpolatedTime) {
+        float alpha = mFromAlpha;
+        alpha = alpha + ((mToAlpha - alpha) * interpolatedTime);
+        setAlpha(alpha);
+    }
+    void resetPosition(int horizontalRandomness) {
+        srand((unsigned)time(NULL));
+        translationX = rand() % horizontalRandomness;
+    }
+    void start(float fromAlpha, float toAlpha) {
+        mFromAlpha = fromAlpha;
+        mToAlpha = toAlpha;
+    }
+    void setAlpha(float alpha) { OH_Drawing_PenSetAlpha(mPaint, (int)(alpha * 255)); }
+    void draw(OH_Drawing_Canvas *canvas) {
+        OH_Drawing_CanvasAttachPen(canvas, mPaint);
+        OH_Drawing_CanvasDrawLine(canvas, mCStartPoint.x, mCStartPoint.y, mCEndPoint.x, mCEndPoint.y);
+        OH_Drawing_CanvasDetachPen(canvas);
+    }
+
+public:
+    PointF midPoint;
+    float translationX;
+    int index;
+
+private:
+    OH_Drawing_Pen *mPaint{OH_Drawing_PenCreate()};
+    float mFromAlpha{1.0f};
+    float mToAlpha{0.4f};
+    PointF mCStartPoint;
+    PointF mCEndPoint;
+};
+} // namespace rnoh
+#endif // HARMONY_RNCSTOREHOUSEBARITEM_H

--- a/harmony/smart_refresh_layout/src/main/cpp/RNCStoreHouseHeaderComponentInstance.cpp
+++ b/harmony/smart_refresh_layout/src/main/cpp/RNCStoreHouseHeaderComponentInstance.cpp
@@ -1,0 +1,52 @@
+//
+// Created on 2024/3/30.
+//
+// Node APIs are not fully supported. To solve the compilation error of the interface cannot be found,
+// please include "napi/native_api.h".
+
+#include "RNCStoreHouseHeaderComponentInstance.h"
+#include "RNOH/arkui/NativeNodeApi.h"
+
+namespace rnoh {
+
+RNCStoreHouseHeaderComponentInstance::RNCStoreHouseHeaderComponentInstance(Context context)
+    : CppComponentInstance(std::move(context)) {
+    m_storeHouseNode.setStoreHouseNodeDelegate(this);
+}
+
+void RNCStoreHouseHeaderComponentInstance::onChildInserted(ComponentInstance::Shared const &childComponentInstance,
+                                                           std::size_t index) {
+    CppComponentInstance::onChildInserted(childComponentInstance, index);
+}
+
+void RNCStoreHouseHeaderComponentInstance::onChildRemoved(ComponentInstance::Shared const &childComponentInstance) {
+    CppComponentInstance::onChildRemoved(childComponentInstance);
+};
+
+float RNCStoreHouseHeaderComponentInstance::getVp2Px(float v) {
+    auto rnInstancePtr = this->m_deps->rnInstance.lock();
+    if (rnInstancePtr != nullptr) {
+        auto turboModule = rnInstancePtr->getTurboModule("RNCSmartRefreshContext");
+        auto arkTsTurboModule = std::dynamic_pointer_cast<rnoh::ArkTSTurboModule>(turboModule);
+        folly::dynamic result = arkTsTurboModule->callSync("cvp2px", {v});
+        return result["values"].asDouble();
+    }
+    return -1;
+}
+facebook::react::SharedColor RNCStoreHouseHeaderComponentInstance::GetPrimaryColor() { return -1; };
+void RNCStoreHouseHeaderComponentInstance::onHeaderMove(float dur) { m_storeHouseNode.setProgress(dur); };
+void RNCStoreHouseHeaderComponentInstance::onPropsChanged(SharedConcreteProps const &props) {
+    if (props != nullptr) {
+        m_storeHouseNode.setDropHeight(props->dropHeight);
+        m_storeHouseNode.setFontSize(props->fontSize);
+        m_storeHouseNode.setLineWidth(props->lineWidth);
+        m_storeHouseNode.setTextColor(props->textColor);
+        if (!props->text.empty()) {
+            m_storeHouseNode.setText(props->text);
+        }
+    }
+    m_storeHouseNode.initStoreHouse();
+}
+RNCStoreHouseHeaderNode &RNCStoreHouseHeaderComponentInstance::getLocalRootArkUINode() { return m_storeHouseNode; }
+
+} // namespace rnoh

--- a/harmony/smart_refresh_layout/src/main/cpp/RNCStoreHouseHeaderComponentInstance.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/RNCStoreHouseHeaderComponentInstance.h
@@ -1,0 +1,32 @@
+//
+// Created on 2024/3/30.
+//
+// Node APIs are not fully supported. To solve the compilation error of the interface cannot be found,
+// please include "napi/native_api.h".
+
+#pragma once
+#include "HeaderNodeDelegate.h"
+#include "RNCStoreHouseHeaderNode.h"
+#include "RNOH/CppComponentInstance.h"
+#include "ShadowNodes.h"
+namespace rnoh {
+class RNCStoreHouseHeaderComponentInstance
+    : public CppComponentInstance<facebook::react::RNCStoreHouseHeaderShadowNode>,
+      public StoreHouseNodeDelegate,
+      public HeaderNodeDelegate {
+
+private:
+    RNCStoreHouseHeaderNode m_storeHouseNode;
+
+
+public:
+    RNCStoreHouseHeaderComponentInstance(Context context);
+    void onChildInserted(ComponentInstance::Shared const &childComponentInstance, std::size_t index) override;
+    void onChildRemoved(ComponentInstance::Shared const &childComponentInstance) override;
+    void onPropsChanged(SharedConcreteProps const &props) override;
+    RNCStoreHouseHeaderNode &getLocalRootArkUINode() override;
+    float getVp2Px(float v) override;
+    facebook::react::SharedColor GetPrimaryColor() override;
+    void onHeaderMove(float dur) override;
+};
+} // namespace rnoh

--- a/harmony/smart_refresh_layout/src/main/cpp/RNCStoreHouseHeaderJSIBinder.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/RNCStoreHouseHeaderJSIBinder.h
@@ -1,0 +1,30 @@
+//
+// Created on 2024/3/30.
+//
+// Node APIs are not fully supported. To solve the compilation error of the interface cannot be found,
+// please include "napi/native_api.h".
+
+#include "RNOH/UIManagerModule.h"
+#include "RNOH/BaseComponentJSIBinder.h"
+#include "RNOHCorePackage/ComponentBinders/ViewComponentJSIBinder.h"
+
+namespace rnoh {
+class RNCStoreHouseHeaderJSIBinder : public ViewComponentJSIBinder {
+protected:
+    facebook::jsi::Object createBubblingEventTypes(facebook::jsi::Runtime &rt) override {
+        auto events = ViewComponentJSIBinder::createBubblingEventTypes(rt);
+        return events;
+    }
+
+    facebook::jsi::Object createNativeProps(facebook::jsi::Runtime &rt) override {
+        auto nativeProps = ViewComponentJSIBinder::createNativeProps(rt);
+        nativeProps.setProperty(rt, "textColor", "string");
+        nativeProps.setProperty(rt, "text", "string");
+        nativeProps.setProperty(rt, "fontSize", "number");
+        nativeProps.setProperty(rt, "lineWidth", "number");
+        nativeProps.setProperty(rt, "dropHeight", "number");
+        return nativeProps;
+    }
+};
+
+} // namespace rnoh

--- a/harmony/smart_refresh_layout/src/main/cpp/RNCStoreHouseHeaderNapiBinder.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/RNCStoreHouseHeaderNapiBinder.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Huawei Device Co., Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "RNOH/BaseComponentNapiBinder.h"
+#include "Props.h"
+#include "RNOHCorePackage/ComponentBinders/ViewComponentNapiBinder.h"
+
+namespace rnoh {
+
+class RNCStoreHouseHeaderNapiBinder : public ViewComponentNapiBinder {
+public:
+    napi_value createProps(napi_env env, facebook::react::ShadowView const shadowView) override {
+        napi_value napiBaseProps = ViewComponentNapiBinder::createProps(env, shadowView);
+        if (auto props = std::dynamic_pointer_cast<const facebook::react::RNCStoreHouseHeaderProps>(shadowView.props)) {
+            return ArkJS(env)
+                .getObjectBuilder(napiBaseProps)
+                .addProperty("textColor", props->textColor)
+                .addProperty("text", props->text)
+                .addProperty("fontSize", props->fontSize)
+                .addProperty("lineWidth", props->lineWidth)
+                .addProperty("dropHeight", props->dropHeight)
+                .build();
+        }
+        return napiBaseProps;
+    };
+};
+
+} // namespace rnoh

--- a/harmony/smart_refresh_layout/src/main/cpp/RNCStoreHouseHeaderNode.cpp
+++ b/harmony/smart_refresh_layout/src/main/cpp/RNCStoreHouseHeaderNode.cpp
@@ -1,0 +1,172 @@
+#include "RNCStoreHouseHeaderNode.h"
+#include <glog/logging.h>
+#include <arkui/native_node.h>
+#include <native_drawing/drawing_canvas.h>
+#include <native_drawing/drawing_color.h>
+#include <native_drawing/drawing_color.h>
+#include <native_drawing/drawing_point.h>
+#include <native_drawing/drawing_types.h>
+#include "RNOH/arkui/NativeNodeApi.h"
+#include "RNCStoreHousePath.h"
+#include "SmartUtils.h"
+
+namespace rnoh {
+RNCStoreHouseHeaderNode::RNCStoreHouseHeaderNode()
+    : ArkUINode(NativeNodeApi::getInstance()->createNode(ArkUI_NodeType::ARKUI_NODE_CUSTOM)) {
+    canvasCallback_ = new StoreHouseCanvasCallback();
+    // 设置自定义回调。注册onDraw
+    canvasCallback_->callback = [this](ArkUI_NodeCustomEvent *event) {
+        auto type = OH_ArkUI_NodeCustomEvent_GetEventType(event);
+        switch (type) {
+        case ARKUI_NODE_CUSTOM_EVENT_ON_DRAW:
+            OnDraw(event);
+            break;
+        case ARKUI_NODE_CUSTOM_EVENT_ON_MEASURE: {
+            int32_t width = getSavedWidth();
+            int32_t height = getSavedHeight();
+            maybeThrow(NativeNodeApi::getInstance()->setMeasuredSize(m_nodeHandle, width,
+                                                                     mDropHeight + delegate->getVp2Px(40)));
+        } break;
+        default:
+            break;
+        }
+    };
+    eventReceiver = [](ArkUI_NodeCustomEvent *event) {
+        int32_t targetId = OH_ArkUI_NodeCustomEvent_GetEventTargetId(event);
+        if (targetId == 1001 || targetId == 1002) {
+            auto *userData = reinterpret_cast<StoreHouseCanvasCallback *>(OH_ArkUI_NodeCustomEvent_GetUserData(event));
+            if (userData != nullptr && userData->callback != nullptr) {
+                userData->callback(event);
+            }
+        }
+    };
+
+    maybeThrow(NativeNodeApi::getInstance()->addNodeCustomEventReceiver(m_nodeHandle, eventReceiver));
+    maybeThrow(NativeNodeApi::getInstance()->registerNodeCustomEvent(m_nodeHandle, ARKUI_NODE_CUSTOM_EVENT_ON_MEASURE,
+                                                                     1001, canvasCallback_));
+    maybeThrow(NativeNodeApi::getInstance()->registerNodeCustomEvent(m_nodeHandle, ARKUI_NODE_CUSTOM_EVENT_ON_DRAW,
+                                                                     1002, canvasCallback_));
+}
+
+RNCStoreHouseHeaderNode::~RNCStoreHouseHeaderNode() {
+    NativeNodeApi::getInstance()->removeNodeCustomEventReceiver(m_nodeHandle, eventReceiver);
+    NativeNodeApi::getInstance()->unregisterNodeCustomEvent(m_nodeHandle, ARKUI_NODE_CUSTOM_EVENT_ON_MEASURE);
+    NativeNodeApi::getInstance()->unregisterNodeCustomEvent(m_nodeHandle, ARKUI_NODE_CUSTOM_EVENT_ON_DRAW);
+    OH_Drawing_MatrixDestroy(mMatrix);
+    OH_Drawing_CanvasDestroy(canvas);
+    mItemList.clear();
+    delete canvasCallback_;
+    canvasCallback_ = nullptr;
+}
+void RNCStoreHouseHeaderNode::setStoreHouseNodeDelegate(StoreHouseNodeDelegate *storeHouseNodeDelegate) {
+    delegate = storeHouseNodeDelegate;
+}
+void RNCStoreHouseHeaderNode::initStoreHouse() { initWithString(mText, mFontSize); }
+void RNCStoreHouseHeaderNode::setText(std::string text) { mText = text; }
+void RNCStoreHouseHeaderNode::setTextColor(std::string textColor) { mTextColor = SmartUtils::parseColor(textColor); }
+void RNCStoreHouseHeaderNode::setFontSize(int size) { mFontSize = size; }
+void RNCStoreHouseHeaderNode::setLineWidth(float width) { mLineWidth = delegate->getVp2Px(width); }
+void RNCStoreHouseHeaderNode::setDropHeight(float dropHeight) { mDropHeight = dropHeight; }
+void RNCStoreHouseHeaderNode::initWithString(std::string str, int fontSize) {
+    std::vector<std::vector<float>> pointList = RNCStoreHousePath::getPath(str, fontSize * 0.01f, 14);
+    initWithPointList(pointList);
+}
+void RNCStoreHouseHeaderNode::setProgress(float progress) {
+    mProgress = (progress / 69) * 0.8;
+    markDirty();
+}
+
+bool RNCStoreHouseHeaderNode::isInEditMode() { return true; }
+void RNCStoreHouseHeaderNode::initWithPointList(std::vector<std::vector<float>> pointList) {
+    float drawWidth = 0;
+    float drawHeight = 0;
+    bool shouldLayout = mItemList.size() > 0;
+    if (shouldLayout) {
+        mItemList.clear();
+    }
+
+    for (int i = 0; i < pointList.size(); i++) {
+        std::vector<float> line = pointList[i];
+        PointF startPoint = {delegate->getVp2Px(line[0]) * mScale, delegate->getVp2Px(line[1]) * mScale};
+        PointF endPoint = {delegate->getVp2Px(line[2]) * mScale, delegate->getVp2Px(line[3]) * mScale};
+
+        drawWidth = std::max(drawWidth, startPoint.x);
+        drawWidth = std::max(drawWidth, endPoint.x);
+
+        drawHeight = std::max(drawHeight, startPoint.y);
+        drawHeight = std::max(drawHeight, endPoint.y);
+        auto item = new RNCStoreHouseBarItem(i, startPoint, endPoint, mTextColor, mLineWidth);
+        item->resetPosition(mHorizontalRandomness);
+        mItemList.push_back(item);
+    }
+
+    mDrawZoneWidth = (int)std::ceil(drawWidth);
+    mDrawZoneHeight = (int)std::ceil(drawHeight);
+    if (shouldLayout) {
+        markDirty();
+    }
+}
+void RNCStoreHouseHeaderNode::OnDraw(ArkUI_NodeCustomEvent *event) {
+    auto *drawContext = OH_ArkUI_NodeCustomEvent_GetDrawContextInDraw(event);
+    canvas = reinterpret_cast<OH_Drawing_Canvas *>(OH_ArkUI_DrawContext_GetCanvas(drawContext));
+    auto height = OH_Drawing_CanvasGetHeight(canvas);
+    auto width = OH_Drawing_CanvasGetWidth(canvas);
+    mOffsetX = (width - mDrawZoneWidth) / 2;
+    mOffsetY = (height - mDrawZoneHeight) / 4;
+    mDropHeight = height / 2;
+
+    OH_Drawing_CanvasSave(canvas);
+    int c1 = OH_Drawing_CanvasGetSaveCount(canvas);
+    int len = mItemList.size();
+    float progress = isInEditMode() ? 1 : mProgress;
+    for (int i = 0; i < len; i++) {
+
+        OH_Drawing_CanvasSave(canvas);
+        RNCStoreHouseBarItem *storeHouseBarItem = mItemList[i];
+        float offsetX = mOffsetX + storeHouseBarItem->midPoint.x;
+        float offsetY = mOffsetY + storeHouseBarItem->midPoint.y;
+
+        if (mIsInLoading) {
+            //             storeHouseBarItem.getTransformation(getDrawingTime(), mTransformation);
+            //             canvas.translate(offsetX, offsetY);
+        } else {
+
+            if (progress == 0) {
+                storeHouseBarItem->resetPosition(mHorizontalRandomness);
+                continue;
+            }
+
+            float startPadding = (1 - mInternalAnimationFactor) * i / len;
+            float endPadding = 1 - mInternalAnimationFactor - startPadding;
+
+            // done
+            if (progress == 1 || progress >= 1 - endPadding) {
+                OH_Drawing_CanvasTranslate(canvas, offsetX, offsetY);
+                storeHouseBarItem->setAlpha(mBarDarkAlpha);
+            } else {
+                float realProgress;
+                if (progress <= startPadding) {
+                    realProgress = 0;
+                } else {
+                    realProgress = std::min(1, (int)((progress - startPadding) / mInternalAnimationFactor));
+                }
+                offsetX += storeHouseBarItem->translationX * (1 - realProgress);
+                offsetY += -mDropHeight * (1 - realProgress);
+                OH_Drawing_MatrixReset(mMatrix);
+                OH_Drawing_MatrixPostRotate(mMatrix, 360 * realProgress, width / 2, height / 2);
+                OH_Drawing_MatrixPostScale(mMatrix, realProgress, realProgress, width / 2, height / 2);
+                OH_Drawing_MatrixPostTranslate(mMatrix, offsetX, offsetY);
+                storeHouseBarItem->setAlpha(mBarDarkAlpha * realProgress);
+                OH_Drawing_CanvasConcatMatrix(canvas, mMatrix);
+            }
+        }
+        storeHouseBarItem->draw(canvas);
+        OH_Drawing_CanvasRestore(canvas);
+    }
+    if (mIsInLoading) {
+        markDirty();
+    }
+    OH_Drawing_CanvasRestoreToCount(canvas, c1);
+}
+
+} // namespace rnoh

--- a/harmony/smart_refresh_layout/src/main/cpp/RNCStoreHouseHeaderNode.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/RNCStoreHouseHeaderNode.h
@@ -1,0 +1,62 @@
+#pragma once
+#include "RNOH/arkui/NativeNodeApi.h"
+#include "RNOH/arkui/ArkUINode.h"
+#include "PullToRefreshConfigurator.h"
+#include "react/renderer/graphics/Color.h"
+#include "RNCStoreHouseBarItem.h"
+#include <native_drawing/drawing_matrix.h>
+namespace rnoh {
+class StoreHouseNodeDelegate {
+public:
+    virtual ~StoreHouseNodeDelegate() = default;
+    virtual float getVp2Px(float v){};
+};
+
+struct StoreHouseCanvasCallback {
+    std::function<void(ArkUI_NodeCustomEvent *event)> callback;
+};
+class RNCStoreHouseHeaderNode : public ArkUINode {
+private:
+    StoreHouseCanvasCallback *canvasCallback_{nullptr};
+    void (*eventReceiver)(ArkUI_NodeCustomEvent *event);
+    facebook::react::SharedColor mTextColor{};
+    std::string mText{"StoreHouse"};
+    int mFontSize{25};
+    float mLineWidth{0.0};
+    float mDropHeight{0.0};
+    std::vector<RNCStoreHouseBarItem *> mItemList;
+    float mScale{1};
+    int mHorizontalRandomness{-1};
+    int mDrawZoneWidth{0};
+    int mDrawZoneHeight{0};
+    int mOffsetX{0};
+    int mOffsetY{0};
+    float mProgress{0};
+    bool mIsInLoading{false};
+    float mInternalAnimationFactor{0.7f};
+    float mBarDarkAlpha{0.4f};
+    OH_Drawing_Matrix *mMatrix{OH_Drawing_MatrixCreate()};
+    OH_Drawing_Canvas *canvas;
+    StoreHouseNodeDelegate *delegate;
+
+public:
+    RNCStoreHouseHeaderNode();
+    ~RNCStoreHouseHeaderNode() override;
+
+    void setStoreHouseNodeDelegate(StoreHouseNodeDelegate *delegate);
+    void OnDraw(ArkUI_NodeCustomEvent *event);
+    void setText(std::string text);
+    void setTextColor(std::string textColor);
+    void setFontSize(int size);
+    void setLineWidth(float width);
+    void setDropHeight(float dropHeight);
+    void initStoreHouse();
+    void setProgress(float progress);
+
+private:
+    void initWithString(std::string str, int fontSize);
+    void initWithPointList(std::vector<std::vector<float>>);
+    bool isInEditMode();
+};
+
+} // namespace rnoh

--- a/harmony/smart_refresh_layout/src/main/cpp/RNCStoreHousePath.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/RNCStoreHousePath.h
@@ -1,0 +1,164 @@
+//
+// Created on 2024/7/7.
+//
+// Node APIs are not fully supported. To solve the compilation error of the interface cannot be found,
+// please include "napi/native_api.h".
+
+#ifndef HARMONY_RNCSTOREHOUSEPATH_H
+#define HARMONY_RNCSTOREHOUSEPATH_H
+#include <iostream>
+#include <vector>
+#include <glog/logging.h>
+
+std::vector<float> point_a{24, 0, 1, 22, 1, 22, 1, 72, 24, 0, 47, 22, 47, 22, 47, 72, 1, 48, 47, 48};
+std::vector<float> point_b{0,  0,  0, 72, 0,  0,  37, 0,  37, 0,  47, 11, 47, 11, 47, 26, 47, 26, 38, 36,
+                           38, 36, 0, 36, 38, 36, 47, 46, 47, 46, 47, 61, 47, 61, 38, 71, 37, 72, 0,  72};
+std::vector<float> point_c{47, 0, 0, 0, 0, 0, 0, 72, 0, 72, 47, 72};
+std::vector<float> point_d{0, 0, 0, 72, 0, 0, 24, 0, 24, 0, 47, 22, 47, 22, 47, 48, 47, 48, 23, 72, 23, 72, 0, 72};
+std::vector<float> point_e{0, 0, 0, 72, 0, 0, 47, 0, 0, 36, 37, 36, 0, 72, 47, 72};
+std::vector<float> point_f{0, 0, 0, 72, 0, 0, 47, 0, 0, 36, 37, 36};
+std::vector<float> point_g{47, 23, 47, 0, 47, 0, 0, 0, 0, 0, 0, 72, 0, 72, 47, 72, 47, 72, 47, 48, 47, 48, 24, 48};
+std::vector<float> point_h{0, 0, 0, 72, 0, 36, 47, 36, 47, 0, 47, 72};
+std::vector<float> point_i{0, 0, 47, 0, 24, 0, 24, 72, 0, 72, 47, 72};
+std::vector<float> point_j{47, 0, 47, 72, 47, 72, 24, 72, 24, 72, 0, 48};
+std::vector<float> point_k{0, 0, 0, 72, 47, 0, 3, 33, 3, 38, 47, 72};
+std::vector<float> point_l{0, 0, 0, 72, 0, 72, 47, 72};
+std::vector<float> point_m{0, 0, 0, 72, 0, 0, 24, 23, 24, 23, 47, 0, 47, 0, 47, 72};
+std::vector<float> point_n{0, 0, 0, 72, 0, 0, 47, 72, 47, 72, 47, 0};
+std::vector<float> point_o{0, 0, 0, 72, 0, 72, 47, 72, 47, 72, 47, 0, 47, 0, 0, 0};
+std::vector<float> point_p{0, 0, 0, 72, 0, 0, 47, 0, 47, 0, 47, 36, 47, 36, 0, 36};
+std::vector<float> point_q{0, 0, 0, 72, 0, 72, 23, 72, 23, 72, 47, 48, 47, 48, 47, 0, 47, 0, 0, 0, 24, 28, 47, 71};
+std::vector<float> point_r{0, 0, 0, 72, 0, 0, 47, 0, 47, 0, 47, 36, 47, 36, 0, 36, 0, 37, 47, 72};
+std::vector<float> point_s{47, 0, 0, 0, 0, 0, 0, 36, 0, 36, 47, 36, 47, 36, 47, 72, 47, 72, 0, 72};
+std::vector<float> point_t{0, 0, 47, 0, 24, 0, 24, 72};
+std::vector<float> point_u{0, 0, 0, 72, 0, 72, 47, 72, 47, 72, 47, 0};
+std::vector<float> point_v{0, 0, 24, 72, 24, 72, 47, 0};
+std::vector<float> point_w{0, 0, 0, 72, 0, 72, 24, 49, 24, 49, 47, 72, 47, 72, 47, 0};
+std::vector<float> point_x{0, 0, 47, 72, 47, 0, 0, 72};
+std::vector<float> point_y{0, 0, 24, 23, 47, 0, 24, 23, 24, 23, 24, 72};
+std::vector<float> point_z{0, 0, 47, 0, 47, 0, 0, 72, 0, 72, 47, 72};
+std::vector<float> point_0{0, 0, 0, 72, 0, 72, 47, 72, 47, 72, 47, 0, 47, 0, 0, 0};
+std::vector<float> point_1{24, 0, 24, 72};
+std::vector<float> point_2{0, 0, 47, 0, 47, 0, 47, 36, 47, 36, 0, 36, 0, 36, 0, 72, 0, 72, 47, 72};
+std::vector<float> point_3{0, 0, 47, 0, 47, 0, 47, 36, 47, 36, 0, 36, 47, 36, 47, 72, 47, 72, 0, 72};
+std::vector<float> point_4{0, 0, 0, 36, 0, 36, 47, 36, 47, 0, 47, 72};
+std::vector<float> point_5{0, 0, 0, 36, 0, 36, 47, 36, 47, 36, 47, 72, 47, 72, 0, 72, 0, 0, 47, 0};
+std::vector<float> point_6{0, 0, 0, 72, 0, 72, 47, 72, 47, 72, 47, 36, 47, 36, 0, 36};
+std::vector<float> point_7{0, 0, 47, 0, 47, 0, 47, 72};
+std::vector<float> point_8{0, 0, 0, 72, 0, 72, 47, 72, 47, 72, 47, 0, 47, 0, 0, 0, 0, 36, 47, 36};
+std::vector<float> point_9{47, 0, 0, 0, 0, 0, 0, 36, 0, 36, 47, 36, 47, 0, 47, 72};
+namespace rnoh {
+class RNCStoreHousePath {
+private:
+    static std::vector<float> getArrayByChar(char c) {
+        if (c >= 'a' && c <= 'z') {
+            c = c - 32;
+        }
+        switch (c) {
+        case 'A':
+            return point_a;
+        case 'B':
+            return point_b;
+        case 'C':
+            return point_c;
+        case 'D':
+            return point_d;
+        case 'E':
+            return point_e;
+        case 'F':
+            return point_f;
+        case 'G':
+            return point_g;
+        case 'H':
+            return point_h;
+        case 'I':
+            return point_i;
+        case 'J':
+            return point_j;
+        case 'K':
+            return point_k;
+        case 'L':
+            return point_l;
+        case 'M':
+            return point_m;
+    case 'N':
+            return point_n;
+        case 'O':
+            return point_o;
+        case 'P':
+            return point_p;
+        case 'Q':
+            return point_q;
+        case 'R':
+            return point_r;
+        case 'S':
+            return point_s;
+        case 'T':
+            return point_t;
+        case 'U':
+            return point_u;
+        case 'V':
+            return point_v;
+        case 'W':
+            return point_w;
+        case 'X':
+            return point_x;
+        case 'Y':
+            return point_y;
+        case 'Z':
+            return point_z;
+        case '0':
+            return point_0;
+        case '1':
+            return point_1;
+        case '2':
+            return point_2;
+        case '3':
+            return point_3;
+        case '4':
+            return point_4;
+        case '5':
+            return point_5;
+        case '6':
+            return point_6;
+        case '7':
+            return point_7;
+        case '8':
+            return point_8;
+        case '9':
+            return point_9;
+        default:
+            throw "error:the character is not supported,only a-z and 0-9 are supported";
+        }
+    }
+public:
+    static std::vector<std::vector<float>> getPath(std::string str, float scale, int gapBetweenLetter) {
+        std::vector<std::vector<float>> list;
+        float offsetForWidth = 0;
+        for (int i = 0; i < str.length(); i++) {
+            int pos = str[i];
+            std::vector<float> points = getArrayByChar(pos);
+            int pointCount = points.size() / 4;
+            for (int j = 0; j < pointCount; j++) {
+                std::vector<float> line(4);
+                for (int k = 0; k < 4; k++) {
+                    float l = points[j * 4 + k];
+                    // x
+                    if (k % 2 == 0) {
+                        line[k] = (l + offsetForWidth) * scale;
+                    }
+                    // y
+                    else {
+                        line[k] = l * scale;
+                    }
+                }
+                list.push_back(line);
+            }
+            offsetForWidth += 57 + gapBetweenLetter;
+        }
+        return list;
+    }
+};
+} // namespace rnoh
+
+#endif // HARMONY_RNCSTOREHOUSEPATH_H

--- a/harmony/smart_refresh_layout/src/main/cpp/SmartRefreshLayoutPackage.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/SmartRefreshLayoutPackage.h
@@ -36,93 +36,103 @@
 #include "RNCClassicsHeaderComponentInstance.h"
 #include "RNCMaterialHeaderComponentInstance.h"
 #include "RNCSmartRefreshTurboModule.h"
+#include "RNCStoreHouseHeaderComponentInstance.h"
+#include "RNCStoreHouseHeaderJSIBinder.h"
+#include "RNCStoreHouseHeaderNapiBinder.h"
 
 namespace rnoh {
 
-    class SmartRefreshLayoutPackageComponentInstanceFactoryDelegate : public ComponentInstanceFactoryDelegate {
-    public:
-        using ComponentInstanceFactoryDelegate::ComponentInstanceFactoryDelegate;
+class SmartRefreshLayoutPackageComponentInstanceFactoryDelegate : public ComponentInstanceFactoryDelegate {
+public:
+    using ComponentInstanceFactoryDelegate::ComponentInstanceFactoryDelegate;
 
-        ComponentInstance::Shared create(ComponentInstance::Context ctx) override {
-            if (ctx.componentName == "RNCAnyHeader") {
-                globalHeaderType = "RNCAnyHeader";
-                return std::make_shared<RNCAnyHeaderComponentInstance>(std::move(ctx));
-            } else if (ctx.componentName == "SmartRefreshLayout") {
-                return std::make_shared<SmartRefreshLayoutComponentInstance>(std::move(ctx));
-            } else if (ctx.componentName == "RNCDefaultHeader") {
-                globalHeaderType = "RNCDefaultHeader";
-                return std::make_shared<RNCDefaultHeaderComponentInstance>(std::move(ctx));
-            } else if (ctx.componentName == "RNCClassicsHeader") {
-                globalHeaderType = "RNCClassicsHeader";
-                return std::make_shared<RNCClassicsHeaderComponentInstance>(std::move(ctx));
-            } else if (ctx.componentName == "RNCMaterialHeader") {
-                globalHeaderType = "RNCMaterialHeader";
-                return std::make_shared<RNCMaterialHeaderComponentInstance>(std::move(ctx));
-            }
-            return nullptr;
+    ComponentInstance::Shared create(ComponentInstance::Context ctx) override {
+        if (ctx.componentName == "RNCAnyHeader") {
+            globalHeaderType = "RNCAnyHeader";
+            return std::make_shared<RNCAnyHeaderComponentInstance>(std::move(ctx));
+        } else if (ctx.componentName == "SmartRefreshLayout") {
+            return std::make_shared<SmartRefreshLayoutComponentInstance>(std::move(ctx));
+        } else if (ctx.componentName == "RNCDefaultHeader") {
+            globalHeaderType = "RNCDefaultHeader";
+            return std::make_shared<RNCDefaultHeaderComponentInstance>(std::move(ctx));
+        } else if (ctx.componentName == "RNCClassicsHeader") {
+            globalHeaderType = "RNCClassicsHeader";
+            return std::make_shared<RNCClassicsHeaderComponentInstance>(std::move(ctx));
+        } else if (ctx.componentName == "RNCMaterialHeader") {
+            globalHeaderType = "RNCMaterialHeader";
+            return std::make_shared<RNCMaterialHeaderComponentInstance>(std::move(ctx));
+        } else if (ctx.componentName == "RNCStoreHouseHeader") {
+            globalHeaderType = "RNCStoreHouseHeader";
+            return std::make_shared<RNCStoreHouseHeaderComponentInstance>(std::move(ctx));
         }
-    };
+        return nullptr;
+    }
+};
 
-    class RNCSmartRefreshFactoryDelegate : public TurboModuleFactoryDelegate {
-    public:
-        SharedTurboModule createTurboModule(Context ctx, const std::string &name) const override {
-            if (name == "RNCSmartRefreshContext") {
-                return std::make_shared<RNCSmartRefreshTurboModule>(ctx, name);
-            }
-            return nullptr;
+class RNCSmartRefreshFactoryDelegate : public TurboModuleFactoryDelegate {
+public:
+    SharedTurboModule createTurboModule(Context ctx, const std::string &name) const override {
+        if (name == "RNCSmartRefreshContext") {
+            return std::make_shared<RNCSmartRefreshTurboModule>(ctx, name);
+        }
+        return nullptr;
+    };
+};
+
+class SmartRefreshLayoutPackage : public Package {
+public:
+    SmartRefreshLayoutPackage(Package::Context ctx) : Package(ctx) {}
+
+    ComponentInstanceFactoryDelegate::Shared createComponentInstanceFactoryDelegate() override {
+        return std::make_shared<SmartRefreshLayoutPackageComponentInstanceFactoryDelegate>();
+    }
+
+    std::unique_ptr<TurboModuleFactoryDelegate> createTurboModuleFactoryDelegate() override {
+        return std::make_unique<RNCSmartRefreshFactoryDelegate>();
+    }
+
+    std::vector<facebook::react::ComponentDescriptorProvider> createComponentDescriptorProviders() override {
+        return {
+            facebook::react::concreteComponentDescriptorProvider<
+                facebook::react::SmartRefreshLayoutComponentDescriptor>(),
+            facebook::react::concreteComponentDescriptorProvider<
+                facebook::react::RNCAnyHeaderComponentDescriptor>(),
+            facebook::react::concreteComponentDescriptorProvider<
+                facebook::react::RNCDefaultHeaderComponentDescriptor>(),
+            facebook::react::concreteComponentDescriptorProvider<
+                facebook::react::RNCMaterialHeaderComponentDescriptor>(),
+            facebook::react::concreteComponentDescriptorProvider<
+                facebook::react::RNCClassicsHeaderComponentDescriptor>(),
+            facebook::react::concreteComponentDescriptorProvider<
+                facebook::react::RNCStoreHouseHeaderComponentDescriptor>(),
         };
-    };
+    }
 
-    class SmartRefreshLayoutPackage : public Package {
-    public:
-        SmartRefreshLayoutPackage(Package::Context ctx) : Package(ctx) {}
+    ComponentJSIBinderByString createComponentJSIBinderByName() override {
+        return {
+            {"SmartRefreshLayout", std::make_shared<SmartRefreshLayoutJSIBinder>()},
+            {"RNCAnyHeader", std::make_shared<RNCAnyHeaderJSIBinder>()},
+            {"RNCDefaultHeader", std::make_shared<RNCDefaultHeaderJSIBinder>()},
+            {"RNCClassicsHeader", std::make_shared<RNCClassicsHeaderJSIBinder>()},
+            {"RNCMaterialHeader", std::make_shared<RNCMaterialHeaderJSIBinder>()},
+            {"RNCStoreHouseHeader", std::make_shared<RNCStoreHouseHeaderJSIBinder>()},
+        };
+    }
 
-        ComponentInstanceFactoryDelegate::Shared createComponentInstanceFactoryDelegate() override {
-            return std::make_shared<SmartRefreshLayoutPackageComponentInstanceFactoryDelegate>();
-        }
+    ComponentNapiBinderByString createComponentNapiBinderByName() override {
+        return {
+            {"SmartRefreshLayout", std::make_shared<SmartRefreshLayoutNapiBinder>()},
+            {"RNCAnyHeader", std::make_shared<RNCAnyHeaderNapiBinder>()},
+            {"RNCDefaultHeader", std::make_shared<RNCDefaultHeaderNapiBinder>()},
+            {"RNCClassicsHeader", std::make_shared<RNCClassicsHeaderNapiBinder>()},
+            {"RNCMaterialHeader", std::make_shared<RNCMaterialHeaderNapiBinder>()},
+            {"RNCStoreHouseHeader", std::make_shared<RNCStoreHouseHeaderNapiBinder>()},
+        };
+    }
 
-       std::unique_ptr<TurboModuleFactoryDelegate> createTurboModuleFactoryDelegate() override {
-            return std::make_unique<RNCSmartRefreshFactoryDelegate>();
-        }
-    
-        std::vector<facebook::react::ComponentDescriptorProvider> createComponentDescriptorProviders() override {
-            return {
-                facebook::react::concreteComponentDescriptorProvider<
-                    facebook::react::SmartRefreshLayoutComponentDescriptor>(),
-                facebook::react::concreteComponentDescriptorProvider<
-                    facebook::react::RNCAnyHeaderComponentDescriptor>(),
-                facebook::react::concreteComponentDescriptorProvider<
-                    facebook::react::RNCDefaultHeaderComponentDescriptor>(),
-                facebook::react::concreteComponentDescriptorProvider<
-                    facebook::react::RNCMaterialHeaderComponentDescriptor>(),
-                facebook::react::concreteComponentDescriptorProvider<
-                    facebook::react::RNCClassicsHeaderComponentDescriptor>(),
-            };
-        }
-
-        ComponentJSIBinderByString createComponentJSIBinderByName() override {
-            return {
-                {"SmartRefreshLayout", std::make_shared<SmartRefreshLayoutJSIBinder>()},
-                {"RNCAnyHeader", std::make_shared<RNCAnyHeaderJSIBinder>()},
-                {"RNCDefaultHeader", std::make_shared<RNCDefaultHeaderJSIBinder>()},
-                {"RNCClassicsHeader", std::make_shared<RNCClassicsHeaderJSIBinder>()},
-                {"RNCMaterialHeader", std::make_shared<RNCMaterialHeaderJSIBinder>()},
-            };
-        }
-
-        ComponentNapiBinderByString createComponentNapiBinderByName() override {
-            return {
-                {"SmartRefreshLayout", std::make_shared<SmartRefreshLayoutNapiBinder>()},
-                {"RNCAnyHeader", std::make_shared<RNCAnyHeaderNapiBinder>()},
-                {"RNCDefaultHeader", std::make_shared<RNCDefaultHeaderNapiBinder>()},
-                {"RNCClassicsHeader", std::make_shared<RNCClassicsHeaderNapiBinder>()},
-                {"RNCMaterialHeader", std::make_shared<RNCMaterialHeaderNapiBinder>()},
-            };
-        }
-
-        EventEmitRequestHandlers createEventEmitRequestHandlers() override {
-            return {std::make_shared<SmartRefreshLayoutEmitRequestHandler>()};
-        }
-    };
+    EventEmitRequestHandlers createEventEmitRequestHandlers() override {
+        return {std::make_shared<SmartRefreshLayoutEmitRequestHandler>()};
+    }
+};
 } // namespace rnoh
 #endif


### PR DESCRIPTION
# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- SmartRefreshLayout新增StoreHouseHeader头部
- Close: #38 

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

