### PR TITLE
fixd:修复SmartRefresh的稳定性，增加手势回调安全判断及其在销毁的时候移除手势监听

### DIFF
--- a/harmony/smart_refresh_layout/.gitignore
+++ b/harmony/smart_refresh_layout/.gitignore
@@ -1,6 +1,0 @@
-/node_modules
-/oh_modules
-/.preview
-/build
-/.cxx
-/.test

--- a/harmony/smart_refresh_layout/BuildProfile.ets
+++ b/harmony/smart_refresh_layout/BuildProfile.ets
@@ -1,9 +1,9 @@
 /**
  * Use these variables when you tailor your ArkTS code. They must be of the const type.
  */
-export const HAR_VERSION = '0.6.7-0.2.16';
-export const BUILD_MODE_NAME = 'release';
-export const DEBUG = false;
+export const HAR_VERSION = '0.6.7-0.2.17-rc.1';
+export const BUILD_MODE_NAME = 'debug';
+export const DEBUG = true;
 export const TARGET_NAME = 'default';
 
 /**

--- a/harmony/smart_refresh_layout/oh-package.json5
+++ b/harmony/smart_refresh_layout/oh-package.json5
@@ -6,7 +6,7 @@
   "name": "@react-native-oh-tpl/react-native-smartrefreshlayout",
   "description": "Please describe the basic information.",
   "main": "index.ets",
-  "version": "0.6.7-0.2.16",
+  "version": "0.6.7-0.2.17",
   "dependencies": {
     "@rnoh/react-native-openharmony": "file:../react_native_openharmony"
   },

--- a/harmony/smart_refresh_layout/src/main/cpp/Animation.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/Animation.h
@@ -6,12 +6,12 @@
 
 #ifndef HARMONY_ANIMATION_H
 #define HARMONY_ANIMATION_H
-#include <iostream>
-#include <thread>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <glog/logging.h>
+#include <iostream>
+#include <thread>
 
 typedef enum {
     ANIMATION_FREE = 0,
@@ -60,7 +60,10 @@ public:
             // 逐步增加t的值来模拟动画进度
             double progress = cubicBezier(t, p0, p1, p2, p3); // 计算CubicBezier曲线上的点作为进度
             currentValue_ = startValue_ + (targetValue_ - startValue_) * progress; // 根据进度计算当前值
-            callback_(currentValue_);                                              // 调用回调函数处理当前值
+            if (callback_) {
+                callback_(currentValue_);
+            }
+            // 调用回调函数处理当前值
             // 暂停以匹配动画的持续时间
             auto currentTime = std::chrono::high_resolution_clock::now();
             auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(currentTime - startTime);
@@ -69,7 +72,9 @@ public:
             }
             startTime = currentTime; // 重置开始时间以计算下一帧的延迟
         }
-        callback_(targetValue_);
+        if (callback_) {
+            callback_(targetValue_);
+        }
         state_ = Animation_State::ANIMATION_FINISH;
     }
 
@@ -84,9 +89,7 @@ private:
     std::thread *updateThread_; // 使用指针是为了能够动态分配线程对象
     std::function<void(double)> callback_;
 
-    double cubicBezier(double t, double p0, double p1, double p2, double p3) {
-        return (1 - t) * p0 + p3 * t;
-    }
+    double cubicBezier(double t, double p0, double p1, double p2, double p3) { return (1 - t) * p0 + p3 * t; }
     void cancelAnimation() {
         state_ = Animation_State::ANIMATION_FREE;
         // 等待线程结束

--- a/harmony/smart_refresh_layout/src/main/cpp/PullToRefreshNode.cpp
+++ b/harmony/smart_refresh_layout/src/main/cpp/PullToRefreshNode.cpp
@@ -9,7 +9,9 @@ namespace rnoh {
           m_headerArkUINodeHandle(nullptr), m_listArkUINodeHandle(nullptr), m_pullToRefreshNodeDelegate(nullptr),
           refreshConfigurator{std::make_shared<PullToRefreshConfigurator>()}{}
 
-    PullToRefreshNode::~PullToRefreshNode() {}
+    PullToRefreshNode::~PullToRefreshNode() {
+        refreshConfigurator = nullptr;
+    }
     void PullToRefreshNode::setPullToRefreshNodeDelegate(PullToRefreshNodeDelegate *pullToRefreshNodeDelegate) {
         m_pullToRefreshNodeDelegate = pullToRefreshNodeDelegate;
     }

--- a/harmony/smart_refresh_layout/src/main/cpp/PullToRefreshNode.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/PullToRefreshNode.h
@@ -6,44 +6,51 @@
 
 namespace rnoh {
 
-    class PullToRefreshNodeDelegate {
-    public:
-        virtual ~PullToRefreshNodeDelegate() = default;
-        virtual void onRefresh(){};
-        virtual void onHeaderPulling(const float &displayedHeaderHeight){};
-        virtual void onHeaderReleasing(const float &displayedHeaderHeight){};
-        virtual void onHeaderMoving(const float &displayedHeaderHeight){};
-        virtual void onPullDownToRefresh(){};
-        virtual void onHeaderReleased(){};
-        virtual void onReleaseToRefresh(){};
-        virtual bool isComponentTop(){};
-        virtual void onAppArea(){};
-    };
+class PullToRefreshNodeDelegate {
+public:
+    virtual ~PullToRefreshNodeDelegate() = default;
+    virtual void onRefresh(){};
+    virtual void onHeaderPulling(const float &displayedHeaderHeight){};
+    virtual void onHeaderReleasing(const float &displayedHeaderHeight){};
+    virtual void onHeaderMoving(const float &displayedHeaderHeight){};
+    virtual void onPullDownToRefresh(){};
+    virtual void onHeaderReleased(){};
+    virtual void onReleaseToRefresh(){};
+    virtual bool isComponentTop(){};
+    virtual void onAppArea(){};
+};
 
-    class PullToRefreshNode : public ArkUINode {
-    protected:
-        ArkUI_NodeHandle m_headerArkUINodeHandle;
-        ArkUI_NodeHandle m_listArkUINodeHandle;
-        PullToRefreshNodeDelegate *m_pullToRefreshNodeDelegate;
-        std::shared_ptr<PullToRefreshConfigurator> refreshConfigurator;
+class PullToRefreshNode : public ArkUINode {
+protected:
+    ArkUI_NodeHandle m_headerArkUINodeHandle;
+    ArkUI_NodeHandle m_listArkUINodeHandle;
+    PullToRefreshNodeDelegate *m_pullToRefreshNodeDelegate;
+    std::shared_ptr<PullToRefreshConfigurator> refreshConfigurator;
 
-    public:
-        PullToRefreshNode();
-        ~PullToRefreshNode() override;
+public:
+    PullToRefreshNode();
+    ~PullToRefreshNode() override;
 
-        void insertChild(ArkUINode &child, std::size_t index);
+    void insertChild(ArkUINode &child, std::size_t index);
 
-        void removeChild(ArkUINode &child);
+    void removeChild(ArkUINode &child);
 
-        void setPullToRefreshNodeDelegate(PullToRefreshNodeDelegate *pullToRefreshNodeDelegate);
+    void setPullToRefreshNodeDelegate(PullToRefreshNodeDelegate *pullToRefreshNodeDelegate);
 
-        void setHeaderHeight(float h);
-        void setEnableRefresh(bool enable);
-        void setMaxTranslate(float maxHeight);
-        void setHeaderBackgroundColor(facebook::react::SharedColor const &color);
-        PullToRefreshConfigurator getPullToRefreshConfigurator() { return *refreshConfigurator; }
-        void onNodeEvent(ArkUI_NodeEventType eventType, EventArgs &eventArgs) override;
-        void setSensitivity(float setSensitivity);
-    };
+    void setHeaderHeight(float h);
+    void setEnableRefresh(bool enable);
+    void setMaxTranslate(float maxHeight);
+    void setHeaderBackgroundColor(facebook::react::SharedColor const &color);
+
+    PullToRefreshConfigurator *getPullToRefreshConfigurator() {
+        std::weak_ptr<PullToRefreshConfigurator> config = std::move(refreshConfigurator);
+        if (config.lock()) {
+            return config.lock().get();
+        }
+        return std::move(refreshConfigurator).get();
+    }
+    void onNodeEvent(ArkUI_NodeEventType eventType, EventArgs &eventArgs) override;
+    void setSensitivity(float setSensitivity);
+};
 
 } // namespace rnoh

--- a/harmony/smart_refresh_layout/src/main/cpp/RNCAnyHeaderComponentInstance.cpp
+++ b/harmony/smart_refresh_layout/src/main/cpp/RNCAnyHeaderComponentInstance.cpp
@@ -15,6 +15,7 @@ namespace rnoh {
                                                         std::size_t index) {
         CppComponentInstance::onChildInserted(childComponentInstance, index);
         m_stackNode.insertChild(childComponentInstance->getLocalRootArkUINode(), index);
+    
     }
 
     void RNCAnyHeaderComponentInstance::onChildRemoved(ComponentInstance::Shared const &childComponentInstance) {

--- a/harmony/smart_refresh_layout/src/main/cpp/SmartRefreshLayoutComponentInstance.cpp
+++ b/harmony/smart_refresh_layout/src/main/cpp/SmartRefreshLayoutComponentInstance.cpp
@@ -1,233 +1,52 @@
 #include "SmartRefreshLayoutComponentInstance.h"
-#include <folly/dynamic.h>
-#include <bits/alltypes.h>
+#include "RNCDefaultHeaderComponentInstance.h"
 #include "RNOH/arkui/ArkUINode.h"
+#include "RNOH/arkui/NativeNodeApi.h"
 #include "RNOHCorePackage/ComponentInstances/ScrollViewComponentInstance.h"
 #include "TaskProcessor.h"
 #include "react/renderer/graphics/Color.h"
 #include <arkui/native_interface.h>
 #include <arkui/native_node.h>
-#include <arkui/native_gesture.h>
-#include "RNOH/arkui/NativeNodeApi.h"
-#include "RNCDefaultHeaderComponentInstance.h"
+#include <bits/alltypes.h>
+#include <folly/dynamic.h>
 #include <react/renderer/graphics/Geometry.h>
 
 namespace rnoh {
 
-    SmartRefreshLayoutComponentInstance::SmartRefreshLayoutComponentInstance(Context context)
-        : CppComponentInstance(std::move(context)) {
+SmartRefreshLayoutComponentInstance::SmartRefreshLayoutComponentInstance(Context context)
+    : CppComponentInstance(std::move(context)) {
 
-        m_pullToRefreshNode.insertChild(m_headerStackNode, 0);
-        m_pullToRefreshNode.insertChild(m_listStackNode, 1);
-        m_headerStackNode.setAlign(ARKUI_ALIGNMENT_BOTTOM);
-        m_headerStackNode.setAlignment(ARKUI_ALIGNMENT_BOTTOM);
-        m_pullToRefreshNode.setPullToRefreshNodeDelegate(this);
+    m_pullToRefreshNode.insertChild(m_headerStackNode, 0);
+    m_pullToRefreshNode.insertChild(m_listStackNode, 1);
+    m_headerStackNode.setAlign(ARKUI_ALIGNMENT_BOTTOM);
+    m_headerStackNode.setAlignment(ARKUI_ALIGNMENT_BOTTOM);
+    m_pullToRefreshNode.setPullToRefreshNodeDelegate(this);
 
-        ArkUI_NumberValue clipValue[] = {{.u32 = 1}};
-        ArkUI_AttributeItem clipItem = {clipValue, sizeof(clipValue) / sizeof(ArkUI_NumberValue)};
-        NativeNodeApi::getInstance()->setAttribute(m_headerStackNode.getArkUINodeHandle(), NODE_CLIP, &clipItem);
-        panGesture(m_pullToRefreshNode.getArkUINodeHandle());
-        NativeNodeApi::getInstance()->registerNodeEvent(m_pullToRefreshNode.getArkUINodeHandle(), NODE_EVENT_ON_APPEAR,
-                                                        NODE_EVENT_ON_APPEAR, this);
-    }
+    ArkUI_NumberValue clipValue[] = {{.u32 = 1}};
+    ArkUI_AttributeItem clipItem = {clipValue, sizeof(clipValue) / sizeof(ArkUI_NumberValue)};
+    NativeNodeApi::getInstance()->setAttribute(m_headerStackNode.getArkUINodeHandle(), NODE_CLIP, &clipItem);
+    panGesture(m_pullToRefreshNode.getArkUINodeHandle());
+    NativeNodeApi::getInstance()->registerNodeEvent(m_pullToRefreshNode.getArkUINodeHandle(), NODE_EVENT_ON_APPEAR,
+                                                    NODE_EVENT_ON_APPEAR, this);
+}
+SmartRefreshLayoutComponentInstance::~SmartRefreshLayoutComponentInstance() {
 
-    void SmartRefreshLayoutComponentInstance::onAppArea() {
-        if (this->autoRefresh.refresh) {
-            int32_t delayTime = (int32_t)autoRefresh.time;
-            if (delayTime > 0) {
-                TaskProcessor *taskProcessor = new TaskProcessor();
-                taskProcessor->startDelayTask(static_cast<std::chrono::milliseconds>(delayTime), [this]() {
-                    auto instance = std::static_pointer_cast<RNInstanceInternal>(m_deps->rnInstance.lock());
-                    if (!instance) {
-                        return;
-                    }
-                    instance->getTaskExecutor()->runTask(
-                        TaskThread::MAIN, [wptr = this->weak_from_this(), wInstance = instance->weak_from_this()] {
-                            auto ptr = std::static_pointer_cast<SmartRefreshLayoutComponentInstance>(wptr.lock());
-                            if (ptr) {
-                                ptr->trYTop = ptr->headerHeight * 2;
-                                ptr->onActionEnd();
-                            }
-                        });
-                });
-            } else {
-                this->trYTop = this->headerHeight * 2;
-                this->onActionEnd();
-            }
-        }
-    };
-
-    void SmartRefreshLayoutComponentInstance::finalizeUpdates() {
-        setHeaderChildSize();
-    }  
-
-    void SmartRefreshLayoutComponentInstance::setHeaderChildSize(){
-        if (mWidth != getLayoutMetrics().frame.size.width) {
-            mWidth = getLayoutMetrics().frame.size.width;
-        }
-        setNodeWidth(packageHeaderNode,mWidth);
-        setNodeWidth(m_headerStackNode,mWidth);
-    }
-
-    void SmartRefreshLayoutComponentInstance::setNodeWidth(ArkUINode &arkUINode,float width) {
-        ArkUI_NumberValue widthValue[] = { width };
-        ArkUI_AttributeItem widthItem = {widthValue, sizeof(widthValue) / sizeof(ArkUI_NumberValue)};
-        NativeNodeApi::getInstance()->setAttribute(arkUINode.getArkUINodeHandle(), NODE_WIDTH, &widthItem);
-    }
-
-    void SmartRefreshLayoutComponentInstance::onChildInserted(ComponentInstance::Shared const &childComponentInstance,
-                                                              std::size_t index) {
-        CppComponentInstance::onChildInserted(childComponentInstance, index);
-         
-        mWidth = childComponentInstance->getLayoutMetrics().frame.size.width;
-        if (!isHeaderInserted) {
-            packageHeaderNode.insertChild(childComponentInstance->getLocalRootArkUINode(), 0);
-            m_headerStackNode.insertChild(packageHeaderNode, index);
-            isHeaderInserted = true;
-        } else {
-            m_listStackNode.insertChild(childComponentInstance->getLocalRootArkUINode(), index);
-        }
-    
-        m_headerStackNode.setSize(facebook::react::Size({mWidth, 0}));
-        setOtherHeaderDelegate();
-    }
-
-    void SmartRefreshLayoutComponentInstance::onChildRemoved(ComponentInstance::Shared const &childComponentInstance) {
-        CppComponentInstance::onChildRemoved(childComponentInstance);
-        m_headerStackNode.removeChild(childComponentInstance->getLocalRootArkUINode());
-        m_listStackNode.removeChild(childComponentInstance->getLocalRootArkUINode());
-    };
-
-
-    PullToRefreshNode &SmartRefreshLayoutComponentInstance::getLocalRootArkUINode() { return m_pullToRefreshNode; }
-
-    void SmartRefreshLayoutComponentInstance::panGesture(ArkUI_NodeHandle arkUI_NodeHandle) {
+    if (m_panGesture) {
         auto anyGestureApi = OH_ArkUI_QueryModuleInterfaceByName(ARKUI_NATIVE_GESTURE, "ArkUI_NativeGestureAPI_1");
         auto gestureApi = reinterpret_cast<ArkUI_NativeGestureAPI_1 *>(anyGestureApi);
-        auto panGesture = gestureApi->createPanGesture(1, GESTURE_DIRECTION_VERTICAL, 0.1);
-        auto onPanActionCallBack = [](ArkUI_GestureEvent *event, void *extraParam) {
-            SmartRefreshLayoutComponentInstance *instance = (SmartRefreshLayoutComponentInstance *)extraParam;
-            if (!instance->m_pullToRefreshNode.getPullToRefreshConfigurator().getHasRefresh()) {
-                return;
-            }
-            ArkUI_GestureEventActionType actionType = OH_ArkUI_GestureEvent_GetActionType(event);
-            if (actionType == GESTURE_EVENT_ACTION_ACCEPT) {
-                instance->offsetY = 0;
-                instance->downY = OH_ArkUI_PanGesture_GetOffsetY(event);
-                instance->touchYOld = instance->offsetY;
-                instance->onPullDownToRefresh();
-            } else if (actionType == GESTURE_EVENT_ACTION_UPDATE) {
-                instance->offsetY = OH_ArkUI_PanGesture_GetOffsetY(event) - instance->downY;
-                if (instance->offsetY >= 0) {
-                    instance->onActionUpdate();
-                }
-            } else if (actionType == GESTURE_EVENT_ACTION_END) {
-                instance->onActionEnd();
-                instance->onHeaderReleased();
-            }
-        };
-        gestureApi->setGestureEventTarget(
-            panGesture, GESTURE_EVENT_ACTION_ACCEPT | GESTURE_EVENT_ACTION_UPDATE | GESTURE_EVENT_ACTION_END, this,
-            onPanActionCallBack);
-        gestureApi->addGestureToNode(arkUI_NodeHandle, panGesture, PARALLEL, NORMAL_GESTURE_MASK);
+        if (gestureApi) {
+            gestureApi->removeGestureFromNode(m_pullToRefreshNode.getArkUINodeHandle(), m_panGesture);
+        }
+        m_panGesture = nullptr;
     }
-
-    void SmartRefreshLayoutComponentInstance::onActionUpdate() {
-        if (state == IS_FREE || state == IS_PULL_DOWN_1 || state == IS_PULL_DOWN_2 || state == IS_PULL_UP_1 ||
-            state == IS_PULL_UP_2) {
-            auto maxTranslate = m_pullToRefreshNode.getPullToRefreshConfigurator().getMaxTranslate();
-            touchYNew = offsetY;
-            if (!isComponentTop()) {
-                return;
-            }
-            auto isPullAction = (touchYNew - touchYOld) > 0;
-            if ((state == IS_FREE && isPullAction) || state == IS_PULL_DOWN_1 || state == IS_PULL_DOWN_2) {
-                if (m_pullToRefreshNode.getPullToRefreshConfigurator().getHasRefresh()) {
-                    // 获取最新位移距离
-                    float trY = touchYNew - touchYOld;
-                    // 计算当前需要位移的距离
-                    trYTop = this->getTranslateYOfRefresh(trY);
-                    setPullHeaderHeight(trYTop);
-                    if (trYTop / maxTranslate < 0.5) {
-                        state = IS_PULL_DOWN_1;
-                    } else {
-                        state = IS_PULL_DOWN_2;
-                        // 可释放刷新时触发
-                        this->onReleaseToRefresh();
-                    }
-                    if (trYTop >= 0) {
-                        this->changeStatus();
-                    }
-                }
-            }
-            touchYOld = touchYNew;
-        }
-    }
-
-    void SmartRefreshLayoutComponentInstance::onActionEnd() {
-        auto maxTranslate = m_pullToRefreshNode.getPullToRefreshConfigurator().getMaxTranslate();
-        if (trYTop > 0) {
-            if (state == IS_FREE || state == IS_PULL_DOWN_1 || state == IS_PULL_DOWN_2) {
-                if (trYTop / maxTranslate < 0.5) {
-                    closeRefresh(trYTop, 0, m_pullToRefreshNode.getPullToRefreshConfigurator().getAnimDuration());
-                } else {
-                    state = IS_REFRESHING;
-                    trYTop = maxTranslate * 0.5; // 这个位置要设置高度，收回去
-                    this->onRefresh();
-                    setPullHeaderHeight(trYTop);
-                    this->changeStatus();
-                }
-            }
-        }
-    }
-    float SmartRefreshLayoutComponentInstance::getTranslateYOfRefresh(float newTranslateY) {
-        auto config = m_pullToRefreshNode.getPullToRefreshConfigurator();
-        if (&config != nullptr) {
-            facebook::react::Float maxTranslateY = config.getMaxTranslate();
-            facebook::react::Float sensitivity = config.getSensitivity();
-            //             if (maxTranslateY != 0.0 && sensitivity != 0.0 && trYTop != 0.0) {
-            // 阻尼值计算
-            facebook::react::Float dampingFactor;
-            if ((trYTop / maxTranslateY) < 0.2) {
-                dampingFactor = 1.0;
-            } else if ((trYTop / maxTranslateY) < 0.4) {
-                dampingFactor = 0.8;
-            } else if ((trYTop / maxTranslateY) < 0.6) {
-                dampingFactor = 0.6;
-            } else if ((trYTop / maxTranslateY) < 0.8) {
-                dampingFactor = 0.4;
-            } else {
-                dampingFactor = 0.2;
-            }
-            newTranslateY = newTranslateY * dampingFactor * sensitivity;
-            // 下拉值计算
-            facebook::react::Float newTotalTranslateY = trYTop + newTranslateY;
-            if (newTotalTranslateY > maxTranslateY) {
-                return maxTranslateY;
-            } else if (newTotalTranslateY < 0) {
-                return 0;
-            } else {
-                return newTotalTranslateY;
-            }
-        }
-        //         }
-        return 0;
-    }
-
-    void SmartRefreshLayoutComponentInstance::closeRefresh(float start, float target, int32_t duration) {
-        if (trYTop == target) {
-            return;
-        }
-        if (animation != nullptr &&
-            (animation->GetAnimationStatus() == ANIMATION_START || animation->GetAnimationStatus() == ANIMATION_RUN)) {
-            return;
-        }
-        if (animation == nullptr) {
-            animation = std::make_shared<Animation>();
-        }
-        animation->SetAnimationParams(
-            static_cast<std::chrono::milliseconds>(duration), start, target, [this, &target](double value) {
-                trYTop = value < 0 ? 0 : value;
+    NativeNodeApi::getInstance()->unregisterNodeEvent(m_pullToRefreshNode.getArkUINodeHandle(), NODE_EVENT_ON_APPEAR);
+}
+void SmartRefreshLayoutComponentInstance::onAppArea() {
+    if (this->autoRefresh.refresh) {
+        int32_t delayTime = (int32_t)autoRefresh.time;
+        if (delayTime > 0) {
+            TaskProcessor *taskProcessor = new TaskProcessor();
+            taskProcessor->startDelayTask(static_cast<std::chrono::milliseconds>(delayTime), [this]() {
                 auto instance = std::static_pointer_cast<RNInstanceInternal>(m_deps->rnInstance.lock());
                 if (!instance) {
                     return;
@@ -236,166 +55,395 @@ namespace rnoh {
                     TaskThread::MAIN, [wptr = this->weak_from_this(), wInstance = instance->weak_from_this()] {
                         auto ptr = std::static_pointer_cast<SmartRefreshLayoutComponentInstance>(wptr.lock());
                         if (ptr) {
-                            ptr->setPullHeaderHeight(ptr->trYTop);
-                            if (ptr->trYTop == 0) {
-                                ptr->state = IS_FREE;
-                                ptr->m_pullToRefreshNode.markDirty();
-                                ptr->changeStatus();
-                                if (ptr->animation && ptr->animation->GetAnimationStatus() != ANIMATION_FREE) {
-                                    ptr->animation = nullptr;
-                                }
-                            }
+                            ptr->trYTop = ptr->headerHeight * 2;
+                            ptr->onActionEnd();
                         }
                     });
             });
-        if (animation->GetAnimationStatus() == ANIMATION_FREE || animation->GetAnimationStatus() == ANIMATION_FINISH) {
-            animation->Start();
+        } else {
+            this->trYTop = this->headerHeight * 2;
+            this->onActionEnd();
         }
     }
+};
 
-    void SmartRefreshLayoutComponentInstance::finishRefresh() {
-        state = IS_REFRESHED;
-        changeStatus();
-        closeRefresh(trYTop, 0, m_pullToRefreshNode.getPullToRefreshConfigurator().getAnimDuration());
+void SmartRefreshLayoutComponentInstance::finalizeUpdates() { setHeaderChildSize(); }
+
+void SmartRefreshLayoutComponentInstance::setHeaderChildSize() {
+    if (mWidth != getLayoutMetrics().frame.size.width) {
+        mWidth = getLayoutMetrics().frame.size.width;
+    }
+    setNodeWidth(packageHeaderNode, mWidth);
+    setNodeWidth(m_headerStackNode, mWidth);
+}
+
+void SmartRefreshLayoutComponentInstance::setNodeWidth(ArkUINode &arkUINode, float width) {
+    ArkUI_NumberValue widthValue[] = {width};
+    ArkUI_AttributeItem widthItem = {widthValue, sizeof(widthValue) / sizeof(ArkUI_NumberValue)};
+    NativeNodeApi::getInstance()->setAttribute(arkUINode.getArkUINodeHandle(), NODE_WIDTH, &widthItem);
+}
+
+void SmartRefreshLayoutComponentInstance::onChildInserted(ComponentInstance::Shared const &childComponentInstance,
+                                                          std::size_t index) {
+    CppComponentInstance::onChildInserted(childComponentInstance, index);
+
+    mWidth = childComponentInstance->getLayoutMetrics().frame.size.width;
+    if (!isHeaderInserted) {
+        packageHeaderNode.insertChild(childComponentInstance->getLocalRootArkUINode(), 0);
+        m_headerStackNode.insertChild(packageHeaderNode, index);
+        isHeaderInserted = true;
+    } else {
+        m_listStackNode.insertChild(childComponentInstance->getLocalRootArkUINode(), index);
     }
 
-    bool SmartRefreshLayoutComponentInstance::isComponentTop() {
-        std::vector<ComponentInstance::Shared> child = getChildren();
-        for (ComponentInstance::Shared c : child) {
-            if (c->getComponentName() == "ScrollView") {
-                auto scrollView = std::dynamic_pointer_cast<rnoh::ScrollViewComponentInstance>(c);
-                if (scrollView != nullptr) {
-                    return scrollView->getScrollViewMetrics().contentOffset.y <= 0;
+    m_headerStackNode.setSize(facebook::react::Size({mWidth, 0}));
+    setOtherHeaderDelegate();
+}
+
+void SmartRefreshLayoutComponentInstance::onChildRemoved(ComponentInstance::Shared const &childComponentInstance) {
+    CppComponentInstance::onChildRemoved(childComponentInstance);
+    m_headerStackNode.removeChild(childComponentInstance->getLocalRootArkUINode());
+    m_listStackNode.removeChild(childComponentInstance->getLocalRootArkUINode());
+};
+
+
+PullToRefreshNode &SmartRefreshLayoutComponentInstance::getLocalRootArkUINode() { return m_pullToRefreshNode; }
+
+void SmartRefreshLayoutComponentInstance::panGesture(ArkUI_NodeHandle arkUI_NodeHandle) {
+    auto anyGestureApi = OH_ArkUI_QueryModuleInterfaceByName(ARKUI_NATIVE_GESTURE, "ArkUI_NativeGestureAPI_1");
+    auto gestureApi = reinterpret_cast<ArkUI_NativeGestureAPI_1 *>(anyGestureApi);
+    if (!m_panGesture) {
+        m_panGesture = gestureApi->createPanGesture(1, GESTURE_DIRECTION_VERTICAL, 0.1);
+    }
+    auto onPanActionCallBack = [](ArkUI_GestureEvent *event, void *extraParam) {
+        if (!event || !extraParam) {
+            return;
+        }
+        SmartRefreshLayoutComponentInstance *instance = (SmartRefreshLayoutComponentInstance *)(extraParam);
+        if (!instance)
+            return;
+
+        auto config = instance->m_pullToRefreshNode.getPullToRefreshConfigurator();
+        if (!config || !config->getHasRefresh()) {
+            return;
+        }
+        ArkUI_GestureEventActionType actionType = OH_ArkUI_GestureEvent_GetActionType(event);
+        if (actionType == GESTURE_EVENT_ACTION_ACCEPT) {
+            instance->offsetY = 0;
+            instance->downY = OH_ArkUI_PanGesture_GetOffsetY(event);
+            instance->touchYOld = instance->offsetY;
+            instance->onPullDownToRefresh();
+        } else if (actionType == GESTURE_EVENT_ACTION_UPDATE) {
+            instance->offsetY = OH_ArkUI_PanGesture_GetOffsetY(event) - instance->downY;
+            if (instance->offsetY >= 0) {
+                instance->onActionUpdate();
+            }
+        } else if (actionType == GESTURE_EVENT_ACTION_END) {
+            instance->onActionEnd();
+            instance->onHeaderReleased();
+        }
+    };
+    gestureApi->setGestureEventTarget(
+        m_panGesture, GESTURE_EVENT_ACTION_ACCEPT | GESTURE_EVENT_ACTION_UPDATE | GESTURE_EVENT_ACTION_END, this,
+        onPanActionCallBack);
+    gestureApi->addGestureToNode(arkUI_NodeHandle, m_panGesture, PARALLEL, NORMAL_GESTURE_MASK);
+}
+
+void SmartRefreshLayoutComponentInstance::onActionUpdate() {
+    if (state == IS_FREE || state == IS_PULL_DOWN_1 || state == IS_PULL_DOWN_2 || state == IS_PULL_UP_1 ||
+        state == IS_PULL_UP_2) {
+        auto config = m_pullToRefreshNode.getPullToRefreshConfigurator();
+        if (!config) {
+            return;
+        }
+        auto maxTranslate = config->getMaxTranslate();
+        touchYNew = offsetY;
+        if (!isComponentTop()) {
+            return;
+        }
+        auto isPullAction = (touchYNew - touchYOld) > 0;
+        if ((state == IS_FREE && isPullAction) || state == IS_PULL_DOWN_1 || state == IS_PULL_DOWN_2) {
+            if (config->getHasRefresh()) {
+                // 获取最新位移距离
+                float trY = touchYNew - touchYOld;
+                // 计算当前需要位移的距离
+                trYTop = this->getTranslateYOfRefresh(trY);
+                setPullHeaderHeight(trYTop);
+                if (trYTop / maxTranslate < 0.5) {
+                    state = IS_PULL_DOWN_1;
+                } else {
+                    state = IS_PULL_DOWN_2;
+                    // 可释放刷新时触发
+                    this->onReleaseToRefresh();
+                }
+                if (trYTop >= 0) {
+                    this->changeStatus();
                 }
             }
         }
-        return false;
-    };
-    void SmartRefreshLayoutComponentInstance::onNativeResponderBlockChange(bool blocked) {
+        touchYOld = touchYNew;
+    }
+}
+
+void SmartRefreshLayoutComponentInstance::onActionEnd() {
+    auto config = m_pullToRefreshNode.getPullToRefreshConfigurator();
+    if (!config) {
+        return;
+    }
+    auto maxTranslate = config->getMaxTranslate();
+    if (trYTop > 0) {
+        if (state == IS_FREE || state == IS_PULL_DOWN_1 || state == IS_PULL_DOWN_2) {
+            if (trYTop / maxTranslate < 0.5) {
+                closeRefresh(trYTop, 0, config->getAnimDuration());
+            } else {
+                state = IS_REFRESHING;
+                trYTop = maxTranslate * 0.5; // 这个位置要设置高度，收回去
+                this->onRefresh();
+                setPullHeaderHeight(trYTop);
+                this->changeStatus();
+            }
+        }
+    }
+}
+float SmartRefreshLayoutComponentInstance::getTranslateYOfRefresh(float newTranslateY) {
+    auto config = m_pullToRefreshNode.getPullToRefreshConfigurator();
+    if (config != nullptr) {
+        facebook::react::Float maxTranslateY = config->getMaxTranslate();
+        facebook::react::Float sensitivity = config->getSensitivity();
+        //             if (maxTranslateY != 0.0 && sensitivity != 0.0 && trYTop != 0.0) {
+        // 阻尼值计算
+        facebook::react::Float dampingFactor;
+        if ((trYTop / maxTranslateY) < 0.2) {
+            dampingFactor = 1.0;
+        } else if ((trYTop / maxTranslateY) < 0.4) {
+            dampingFactor = 0.8;
+        } else if ((trYTop / maxTranslateY) < 0.6) {
+            dampingFactor = 0.6;
+        } else if ((trYTop / maxTranslateY) < 0.8) {
+            dampingFactor = 0.4;
+        } else {
+            dampingFactor = 0.2;
+        }
+        newTranslateY = newTranslateY * dampingFactor * sensitivity;
+        // 下拉值计算
+        facebook::react::Float newTotalTranslateY = trYTop + newTranslateY;
+        if (newTotalTranslateY > maxTranslateY) {
+            return maxTranslateY;
+        } else if (newTotalTranslateY < 0) {
+            return 0;
+        } else {
+            return newTotalTranslateY;
+        }
+    }
+    //         }
+    return 0;
+}
+
+void SmartRefreshLayoutComponentInstance::closeRefresh(float start, float target, int32_t duration) {
+    if (trYTop == target) {
+        return;
+    }
+    if (animation != nullptr &&
+        (animation->GetAnimationStatus() == ANIMATION_START || animation->GetAnimationStatus() == ANIMATION_RUN)) {
+        return;
+    }
+    if (animation == nullptr) {
+        animation = std::make_shared<Animation>();
+    }
+    animation->SetAnimationParams(
+        static_cast<std::chrono::milliseconds>(duration), start, target, [this, &target](double value) {
+            trYTop = value < 0 ? 0 : value;
+            auto instance = std::static_pointer_cast<RNInstanceInternal>(m_deps->rnInstance.lock());
+            if (!instance) {
+                return;
+            }
+            instance->getTaskExecutor()->runTask(
+                TaskThread::MAIN, [wptr = this->weak_from_this(), wInstance = instance->weak_from_this()] {
+                    auto ptr = std::static_pointer_cast<SmartRefreshLayoutComponentInstance>(wptr.lock());
+                    if (ptr) {
+                        ptr->setPullHeaderHeight(ptr->trYTop);
+                        if (ptr->trYTop == 0) {
+                            ptr->state = IS_FREE;
+                            ptr->m_pullToRefreshNode.markDirty();
+                            ptr->changeStatus();
+                            if (ptr->animation && ptr->animation->GetAnimationStatus() != ANIMATION_FREE) {
+                                ptr->animation = nullptr;
+                            }
+                        }
+                    }
+                });
+        });
+    if (animation->GetAnimationStatus() == ANIMATION_FREE || animation->GetAnimationStatus() == ANIMATION_FINISH) {
+        animation->Start();
+    }
+}
+
+void SmartRefreshLayoutComponentInstance::finishRefresh() {
+    state = IS_REFRESHED;
+    changeStatus();
+    closeRefresh(trYTop, 0, m_pullToRefreshNode.getPullToRefreshConfigurator()->getAnimDuration());
+}
+
+bool SmartRefreshLayoutComponentInstance::isComponentTop() {
+    std::vector<ComponentInstance::Shared> child = getChildren();
+    for (ComponentInstance::Shared c : child) {
+        if (c->getComponentName() == "ScrollView") {
+            auto scrollView = std::dynamic_pointer_cast<rnoh::ScrollViewComponentInstance>(c);
+            if (scrollView != nullptr) {
+                return scrollView->getScrollViewMetrics().contentOffset.y <= 0;
+            }
+        }
+    }
+    return false;
+};
+void SmartRefreshLayoutComponentInstance::onNativeResponderBlockChange(bool blocked) {
+    std::vector<ComponentInstance::Shared> child = getChildren();
+    for (ComponentInstance::Shared c : child) {
+        if (c->getComponentName() == "ScrollView") {
+            auto scrollView = std::dynamic_pointer_cast<rnoh::ScrollViewComponentInstance>(c);
+            if (blocked) {
+                scrollView->setNativeResponderBlocked(!blocked, "REACT_NATIVE");
+            }
+            break;
+        }
+    }
+}
+
+void SmartRefreshLayoutComponentInstance::onPropsChanged(SharedConcreteProps const &props) {
+    CppComponentInstance::onPropsChanged(props);
+    if (props == nullptr) {
+        return;
+    }
+    headerHeight = props->headerHeight;
+    autoRefresh.refresh = props->autoRefresh.refresh;
+    autoRefresh.time = props->autoRefresh.time;
+    dragRate = props->dragRate;
+    maxDragRate = props->maxDragRate;
+    overScrollBounce = props->overScrollBounce;
+    overScrollDrag = props->overScrollDrag;
+    pureScroll = props->pureScroll;
+    mHeaderBackgroundColor = props->primaryColor;
+    if (delegate != nullptr && (*(delegate->GetPrimaryColor())) != -1) {
+        mHeaderBackgroundColor = delegate->GetPrimaryColor();
+    }
+
+    m_pullToRefreshNode.setHeaderBackgroundColor(mHeaderBackgroundColor);
+    m_pullToRefreshNode.setEnableRefresh(props->enableRefresh);
+    m_pullToRefreshNode.setMaxTranslate(props->headerHeight * (maxDragRate != 2 ? maxDragRate : 2));
+    m_pullToRefreshNode.setSensitivity(dragRate != 0.5 ? dragRate : 0.5);
+}
+
+
+void SmartRefreshLayoutComponentInstance::onRefresh() {
+    if (m_eventEmitter) {
+        m_eventEmitter->onRefresh({});
+    }
+};
+
+void SmartRefreshLayoutComponentInstance::setPullHeaderHeight(float h) {
+
+    if (globalHeaderType == "RNCMaterialHeader" && delegate) {
+        delegate->onHeaderMove(h);
+    } else {
+        m_pullToRefreshNode.setHeaderHeight(h);
+    }
+    // 下拉中
+    if (oldHeaderTop < h) {
+        onHeaderPulling(h);
+    } else if (oldHeaderTop > h) {
+        onHeaderReleasing(h);
+    }
+    oldHeaderTop = h;
+}
+
+void SmartRefreshLayoutComponentInstance::onHeaderPulling(const float &displayedHeaderHeight) {
+    facebook::react::Float percent = displayedHeaderHeight / headerHeight;
+    if (m_eventEmitter) {
+        m_eventEmitter->onHeaderPulling({percent, displayedHeaderHeight, headerHeight});
+    }
+};
+
+void SmartRefreshLayoutComponentInstance::changeStatus() {
+    if (globalHeaderType != "RNCDefaultHeader" && globalHeaderType != "RNCClassicsHeader" &&
+        globalHeaderType != "RNCMaterialHeader") {
+        return;
+    }
+    if (delegate == nullptr) {
+        setOtherHeaderDelegate();
+    } else {
+        delegate->onRefreshStatusChange(state);
+    }
+}
+
+
+void SmartRefreshLayoutComponentInstance::setOtherHeaderDelegate() {
+    if (delegate == nullptr) {
         std::vector<ComponentInstance::Shared> child = getChildren();
         for (ComponentInstance::Shared c : child) {
-            if (c->getComponentName() == "ScrollView") {
-                auto scrollView = std::dynamic_pointer_cast<rnoh::ScrollViewComponentInstance>(c);
-                if (blocked) {
-                    scrollView->setNativeResponderBlocked(!blocked,"REACT_NATIVE");
+            if (c->getComponentName() == "RNCDefaultHeader" || c->getComponentName() == "RNCClassicsHeader" ||
+                c->getComponentName() == "RNCMaterialHeader" || c->getComponentName() == "RNCAnyHeader") {
+                delegate = std::dynamic_pointer_cast<rnoh::HeaderNodeDelegate>(c);
+                if (delegate != nullptr && c->getComponentName() == "RNCMaterialHeader") {
+                    ArkUI_NumberValue clipValue[] = {{.u32 = 1}};
+                    ArkUI_AttributeItem clipItem = {clipValue, sizeof(clipValue) / sizeof(ArkUI_NumberValue)};
+                    NativeNodeApi::getInstance()->setAttribute(m_pullToRefreshNode.getArkUINodeHandle(), NODE_CLIP,
+                                                               &clipItem);
+                    delegate->addHeader(mWidth, 3, &m_pullToRefreshNode);
+                }
+                if (delegate != nullptr && (*(delegate->GetPrimaryColor())) != -1) {
+                    mHeaderBackgroundColor = delegate->GetPrimaryColor();
                 }
                 break;
             }
         }
     }
-
-    void SmartRefreshLayoutComponentInstance::onPropsChanged(SharedConcreteProps const &props) {
-        CppComponentInstance::onPropsChanged(props);
-        if (props == nullptr) {
-            return;
-        }
-        headerHeight = props->headerHeight;
-        autoRefresh.refresh = props->autoRefresh.refresh;
-        autoRefresh.time = props->autoRefresh.time;
-        dragRate = props->dragRate;
-        maxDragRate = props->maxDragRate;
-        overScrollBounce = props->overScrollBounce;
-        overScrollDrag = props->overScrollDrag;
-        pureScroll = props->pureScroll;
-        mHeaderBackgroundColor = props->primaryColor;
-        if (delegate != nullptr && (*(delegate->GetPrimaryColor())) != -1) {
-            mHeaderBackgroundColor = delegate->GetPrimaryColor();
-        }
-
+    if (mHeaderBackgroundColor) {
         m_pullToRefreshNode.setHeaderBackgroundColor(mHeaderBackgroundColor);
-        m_pullToRefreshNode.setEnableRefresh(props->enableRefresh);
-        m_pullToRefreshNode.setMaxTranslate(props->headerHeight * (maxDragRate != 2 ? maxDragRate : 2));
-        m_pullToRefreshNode.setSensitivity(dragRate != 0.5 ? dragRate : 0.5);
     }
-
-
-    void SmartRefreshLayoutComponentInstance::onRefresh() { m_eventEmitter->onRefresh({}); };
-
-    void SmartRefreshLayoutComponentInstance::setPullHeaderHeight(float h) {
-
-        if (globalHeaderType == "RNCMaterialHeader" &&delegate) {
-            delegate->onHeaderMove(h);
-        } else {
-            m_pullToRefreshNode.setHeaderHeight(h);
-        }
-        // 下拉中
-        if (oldHeaderTop < h) {
-            onHeaderPulling(h);
-        } else if (oldHeaderTop > h) {
-            onHeaderReleasing(h);
-        }
-        oldHeaderTop = h;
-    }
-
-    void SmartRefreshLayoutComponentInstance::onHeaderPulling(const float &displayedHeaderHeight) {
-        facebook::react::Float percent = displayedHeaderHeight / headerHeight;
-        m_eventEmitter->onHeaderPulling({percent, displayedHeaderHeight, headerHeight});
-    };
-
-    void SmartRefreshLayoutComponentInstance::changeStatus() {
-        if (globalHeaderType != "RNCDefaultHeader" && globalHeaderType != "RNCClassicsHeader" &&
-            globalHeaderType != "RNCMaterialHeader") {
-            return;
-        }
-        if (delegate == nullptr) {
-            setOtherHeaderDelegate();
-        } else {
-            delegate->onRefreshStatusChange(state);
-        }
-    }
-
-
-    void SmartRefreshLayoutComponentInstance::setOtherHeaderDelegate() {
-        if (delegate == nullptr) {
-            std::vector<ComponentInstance::Shared> child = getChildren();
-            for (ComponentInstance::Shared c : child) {
-                if (c->getComponentName() == "RNCDefaultHeader" || c->getComponentName() == "RNCClassicsHeader" ||
-                    c->getComponentName() == "RNCMaterialHeader" || c->getComponentName() == "RNCAnyHeader") {
-                    delegate = std::dynamic_pointer_cast<rnoh::HeaderNodeDelegate>(c);
-                    if (delegate != nullptr && c->getComponentName() == "RNCMaterialHeader") {
-                        ArkUI_NumberValue clipValue[] = {{.u32 = 1}};
-                        ArkUI_AttributeItem clipItem = {clipValue, sizeof(clipValue) / sizeof(ArkUI_NumberValue)};
-                        NativeNodeApi::getInstance()->setAttribute(m_pullToRefreshNode.getArkUINodeHandle(), NODE_CLIP,
-                                                                   &clipItem);
-                        delegate->addHeader(mWidth, 3, &m_pullToRefreshNode);
-                    }
-                    if (delegate != nullptr && (*(delegate->GetPrimaryColor())) != -1) {
-                        mHeaderBackgroundColor = delegate->GetPrimaryColor();
-                    }
-                    break;
-                }
-            }
-        }
-        m_pullToRefreshNode.setHeaderBackgroundColor(mHeaderBackgroundColor);
-    };
-    void SmartRefreshLayoutComponentInstance::onHeaderReleasing(const float &displayedHeaderHeight) {
-        facebook::react::Float percent = displayedHeaderHeight / headerHeight;
+};
+void SmartRefreshLayoutComponentInstance::onHeaderReleasing(const float &displayedHeaderHeight) {
+    facebook::react::Float percent = displayedHeaderHeight / headerHeight;
+    if (m_eventEmitter) {
         m_eventEmitter->onHeaderReleasing({percent, displayedHeaderHeight, headerHeight});
-    };
+    }
+};
 
-    void SmartRefreshLayoutComponentInstance::onHeaderMoving(const float &displayedHeaderHeight) {
-        facebook::react::Float percent = displayedHeaderHeight / headerHeight;
+void SmartRefreshLayoutComponentInstance::onHeaderMoving(const float &displayedHeaderHeight) {
+    facebook::react::Float percent = displayedHeaderHeight / headerHeight;
+    if (m_eventEmitter) {
         m_eventEmitter->onHeaderMoving({percent, displayedHeaderHeight, headerHeight});
-    };
-    void SmartRefreshLayoutComponentInstance::onPullDownToRefresh() { m_eventEmitter->onPullDownToRefresh({}); };
-    void SmartRefreshLayoutComponentInstance::onReleaseToRefresh() { m_eventEmitter->onReleaseToRefresh({}); };
-    void SmartRefreshLayoutComponentInstance::onHeaderReleased() { m_eventEmitter->onHeaderReleased({}); }
-    void SmartRefreshLayoutComponentInstance::handleCommand(std::string const &commandName,
-                                                            folly::dynamic const &args) {
-        if (commandName == "finishRefresh" && args.isArray() && args.size() == 2) {
-            auto delayed = args[0];
-            auto success = args[1];
-            if (delayed != INFINITY) {
-                if (delayed >= 0) {
-                    m_pullToRefreshNode.getPullToRefreshConfigurator().setFinishDelay(delayed.asInt());
-                } else {
-                    m_pullToRefreshNode.getPullToRefreshConfigurator().setFinishDelay(0);
-                }
+    }
+};
+void SmartRefreshLayoutComponentInstance::onPullDownToRefresh() {
+    if (m_eventEmitter) {
+        m_eventEmitter->onPullDownToRefresh({});
+    }
+};
+void SmartRefreshLayoutComponentInstance::onReleaseToRefresh() {
+    if (m_eventEmitter) {
+        m_eventEmitter->onReleaseToRefresh({});
+    }
+};
+void SmartRefreshLayoutComponentInstance::onHeaderReleased() {
+    if (m_eventEmitter) {
+        m_eventEmitter->onHeaderReleased({});
+    }
+}
+void SmartRefreshLayoutComponentInstance::handleCommand(std::string const &commandName, folly::dynamic const &args) {
+    if (commandName == "finishRefresh" && args.isArray() && args.size() == 2) {
+        auto delayed = args[0];
+        auto success = args[1];
+        if (delayed != INFINITY) {
+            if (delayed >= 0) {
+                m_pullToRefreshNode.getPullToRefreshConfigurator()->setFinishDelay(delayed.asInt());
             } else {
-                m_pullToRefreshNode.getPullToRefreshConfigurator().setFinishDelay(500);
+                m_pullToRefreshNode.getPullToRefreshConfigurator()->setFinishDelay(0);
             }
-            finishRefresh();
+        } else {
+            m_pullToRefreshNode.getPullToRefreshConfigurator()->setFinishDelay(500);
         }
-    };
+        finishRefresh();
+    }
+};
 
 } // namespace rnoh

--- a/harmony/smart_refresh_layout/src/main/cpp/SmartRefreshLayoutComponentInstance.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/SmartRefreshLayoutComponentInstance.h
@@ -1,86 +1,88 @@
 #pragma once
 #include "Animation.h"
+#include "EventEmitters.h"
 #include "HeaderNodeDelegate.h"
 #include "Props.h"
-#include "RNOH/CppComponentInstance.h"
 #include "PullToRefreshNode.h"
-#include "EventEmitters.h"
+#include "RNOH/CppComponentInstance.h"
 #include "ShadowNodes.h"
 #include "SmartRefreshState.h"
 #include "SmartStackNode.h"
+#include <arkui/native_gesture.h>
 
 std::string globalHeaderType = "RNCDefaultHeader";
 
 namespace rnoh {
-    class SmartRefreshLayoutComponentInstance
-        : public CppComponentInstance<facebook::react::SmartRefreshLayoutShadowNode>,
-          public PullToRefreshNodeDelegate {
-    private:
-        PullToRefreshNode m_pullToRefreshNode;
-        SmartStackNode m_headerStackNode;
-        SmartStackNode m_listStackNode;
-        SmartStackNode packageHeaderNode;
-        std::shared_ptr<const facebook::react::SmartRefreshLayoutEventEmitter> m_smartRefreshLayoutEventEmitter;
-        std::shared_ptr<rnoh::HeaderNodeDelegate> delegate;
-        bool overScrollBounce{true};
-        bool enableRefresh{true};
-        facebook::react::Float headerHeight{0.0};
-        bool overScrollDrag{true};
-        bool pureScroll{false};
-        facebook::react::Float dragRate{0.5};
-        facebook::react::Float maxDragRate{2.0};
-        facebook::react::SharedColor mHeaderBackgroundColor{};
-        facebook::react::SmartRefreshLayoutAutoRefreshStruct autoRefresh{};
-        bool isHeaderInserted{false}; // whether list child component inserted
-        float trYTop{0.0};
-        float mWidth{0.0};
-        int32_t state{IS_FREE};
-        int32_t touchYOld{0};
-        int32_t touchYNew{0};
-        float oldHeaderTop{0.0};
-        int32_t downY{0};   // first down touch on Y
-        int32_t offsetY{0}; // pan offset on Y
-        std::shared_ptr<Animation> animation{nullptr};
-        void setOtherHeaderDelegate();
+class SmartRefreshLayoutComponentInstance : public CppComponentInstance<facebook::react::SmartRefreshLayoutShadowNode>,
+                                            public PullToRefreshNodeDelegate {
+private:
+    ArkUI_GestureRecognizer *m_panGesture{nullptr};
 
-    public:
-        SmartRefreshLayoutComponentInstance(Context context);
+    PullToRefreshNode m_pullToRefreshNode;
+    SmartStackNode m_headerStackNode;
+    SmartStackNode m_listStackNode;
+    SmartStackNode packageHeaderNode;
+    std::shared_ptr<const facebook::react::SmartRefreshLayoutEventEmitter> m_smartRefreshLayoutEventEmitter;
+    std::shared_ptr<rnoh::HeaderNodeDelegate> delegate;
+    bool overScrollBounce{true};
+    bool enableRefresh{true};
+    facebook::react::Float headerHeight{0.0};
+    bool overScrollDrag{true};
+    bool pureScroll{false};
+    facebook::react::Float dragRate{0.5};
+    facebook::react::Float maxDragRate{2.0};
+    facebook::react::SharedColor mHeaderBackgroundColor{};
+    facebook::react::SmartRefreshLayoutAutoRefreshStruct autoRefresh{};
+    bool isHeaderInserted{false}; // whether list child component inserted
+    float trYTop{0.0};
+    float mWidth{0.0};
+    int32_t state{IS_FREE};
+    int32_t touchYOld{0};
+    int32_t touchYNew{0};
+    float oldHeaderTop{0.0};
+    int32_t downY{0};   // first down touch on Y
+    int32_t offsetY{0}; // pan offset on Y
+    std::shared_ptr<Animation> animation{nullptr};
+    void setOtherHeaderDelegate();
 
-        void onChildInserted(ComponentInstance::Shared const &childComponentInstance, std::size_t index) override;
+public:
+    SmartRefreshLayoutComponentInstance(Context context);
+    ~SmartRefreshLayoutComponentInstance();
+    void onChildInserted(ComponentInstance::Shared const &childComponentInstance, std::size_t index) override;
 
-        void onChildRemoved(ComponentInstance::Shared const &childComponentInstance) override;
+    void onChildRemoved(ComponentInstance::Shared const &childComponentInstance) override;
 
-        void onPropsChanged(SharedConcreteProps const &props) override;
+    void onPropsChanged(SharedConcreteProps const &props) override;
 
-        bool isComponentTop() override;
-        
-        void setHeaderChildSize();
-        void finalizeUpdates() override;   
-        void setNodeWidth(ArkUINode &arkUINode,float width);
-    
-        PullToRefreshNode &getLocalRootArkUINode() override;
-        void onNativeResponderBlockChange(bool isBlocked)override;
-        void panGesture(ArkUI_NodeHandle arkUI_NodeHandle);
-        float getTranslateYOfRefresh(float newTranslateY);
-        void onActionUpdate();
-        void onActionEnd();
-        void closeRefresh(float start, float target, int32_t duration);
-        void finishRefresh();
-        void setPullHeaderHeight(float h);    
-    
-        void onRefresh() override;
-        void onHeaderPulling(const float &displayedHeaderHeight) override;
-        void onHeaderReleasing(const float &displayedHeaderHeight) override;
-        void onHeaderMoving(const float &displayedHeaderHeight) override;
-        void onPullDownToRefresh() override;
-        void onReleaseToRefresh() override;
-        void onHeaderReleased() override;
-        void onAppArea() override;
-    
-        void handleCommand(std::string const &commandName, folly::dynamic const &args) override;
+    bool isComponentTop() override;
+
+    void setHeaderChildSize();
+    void finalizeUpdates() override;
+    void setNodeWidth(ArkUINode &arkUINode, float width);
+
+    PullToRefreshNode &getLocalRootArkUINode() override;
+    void onNativeResponderBlockChange(bool isBlocked) override;
+    void panGesture(ArkUI_NodeHandle arkUI_NodeHandle);
+    float getTranslateYOfRefresh(float newTranslateY);
+    void onActionUpdate();
+    void onActionEnd();
+    void closeRefresh(float start, float target, int32_t duration);
+    void finishRefresh();
+    void setPullHeaderHeight(float h);
+
+    void onRefresh() override;
+    void onHeaderPulling(const float &displayedHeaderHeight) override;
+    void onHeaderReleasing(const float &displayedHeaderHeight) override;
+    void onHeaderMoving(const float &displayedHeaderHeight) override;
+    void onPullDownToRefresh() override;
+    void onReleaseToRefresh() override;
+    void onHeaderReleased() override;
+    void onAppArea() override;
+
+    void handleCommand(std::string const &commandName, folly::dynamic const &args) override;
 
 
-        //  defaultHeader
-        void changeStatus();
-    };
+    //  defaultHeader
+    void changeStatus();
+};
 } // namespace rnoh

--- a/harmony/smart_refresh_layout/src/main/cpp/SmartRefreshLayoutPackage.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/SmartRefreshLayoutPackage.h
@@ -17,27 +17,27 @@
 #ifndef SMART_SRC_MAIN_CPP_SMARTREFRESHLAYOUTPACKAGE_H
 #define SMART_SRC_MAIN_CPP_SMARTREFRESHLAYOUTPACKAGE_H
 
-#include "RNCClassicsHeaderJSIBinder.h"
-#include "RNCClassicsHeaderNapiBinder.h"
-#include "RNCMaterialHeaderJSIBinder.h"
-#include "RNCMaterialHeaderNapiBinder.h"
-#include "RNOH/Package.h"
 #include "ComponentDescriptors.h"
-#include "SmartRefreshLayoutJSIBinder.h"
-#include "SmartRefreshLayoutNapiBinder.h"
+#include "RNCAnyHeaderComponentInstance.h"
 #include "RNCAnyHeaderJSIBinder.h"
 #include "RNCAnyHeaderNapiBinder.h"
+#include "RNCClassicsHeaderComponentInstance.h"
+#include "RNCClassicsHeaderJSIBinder.h"
+#include "RNCClassicsHeaderNapiBinder.h"
+#include "RNCDefaultHeaderComponentInstance.h"
 #include "RNCDefaultHeaderJSIBinder.h"
 #include "RNCDefaultHeaderNapiBinder.h"
-#include "SmartRefreshLayoutEmitRequestHandler.h"
-#include "RNCAnyHeaderComponentInstance.h"
-#include "SmartRefreshLayoutComponentInstance.h"
-#include "RNCDefaultHeaderComponentInstance.h"
-#include "RNCClassicsHeaderComponentInstance.h"
 #include "RNCMaterialHeaderComponentInstance.h"
+#include "RNCMaterialHeaderJSIBinder.h"
+#include "RNCMaterialHeaderNapiBinder.h"
 #include "RNCStoreHouseHeaderComponentInstance.h"
 #include "RNCStoreHouseHeaderJSIBinder.h"
 #include "RNCStoreHouseHeaderNapiBinder.h"
+#include "RNOH/Package.h"
+#include "SmartRefreshLayoutComponentInstance.h"
+#include "SmartRefreshLayoutEmitRequestHandler.h"
+#include "SmartRefreshLayoutJSIBinder.h"
+#include "SmartRefreshLayoutNapiBinder.h"
 
 namespace rnoh {
 
@@ -75,13 +75,12 @@ public:
     ComponentInstanceFactoryDelegate::Shared createComponentInstanceFactoryDelegate() override {
         return std::make_shared<SmartRefreshLayoutPackageComponentInstanceFactoryDelegate>();
     }
-    
+
     std::vector<facebook::react::ComponentDescriptorProvider> createComponentDescriptorProviders() override {
         return {
             facebook::react::concreteComponentDescriptorProvider<
                 facebook::react::SmartRefreshLayoutComponentDescriptor>(),
-            facebook::react::concreteComponentDescriptorProvider<
-                facebook::react::RNCAnyHeaderComponentDescriptor>(),
+            facebook::react::concreteComponentDescriptorProvider<facebook::react::RNCAnyHeaderComponentDescriptor>(),
             facebook::react::concreteComponentDescriptorProvider<
                 facebook::react::RNCDefaultHeaderComponentDescriptor>(),
             facebook::react::concreteComponentDescriptorProvider<


### PR DESCRIPTION

# Summary

- 修复SmartRefresh的稳定性，增加手势回调安全判断及其在销毁的时候移除手势监听。
- Close: #62 

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)

## Version Info
- react-native-harmony: 0.72.84-CAPI
- DevEco Studio 5.1.1 Release
- OH SDK: HarmonyOS NEXT 5.0.4.150
- ROM: 5.0.0.150(Canary3)
