### PR TITLE
fix:修复不支持“rgba的传值写法及其头部自己设置的背景颜色不起作用

### DIFF
--- a/harmony/smart_refresh_layout/src/main/cpp/SmartRefreshLayoutComponentInstance.cpp
+++ b/harmony/smart_refresh_layout/src/main/cpp/SmartRefreshLayoutComponentInstance.cpp
@@ -418,6 +418,13 @@ void SmartRefreshLayoutComponentInstance::onPullDownToRefresh() {
     if (m_eventEmitter) {
         m_eventEmitter->onPullDownToRefresh({});
     }
+    if (delegate) { // header设置了背景色 
+        facebook::react::SharedColor headerBack = delegate->GetPrimaryColor();
+        if ((*headerBack) != -1 && headerBack != mHeaderBackgroundColor) {
+            mHeaderBackgroundColor = headerBack;
+            m_pullToRefreshNode.setHeaderBackgroundColor(mHeaderBackgroundColor);
+        }
+    }
 };
 void SmartRefreshLayoutComponentInstance::onReleaseToRefresh() {
     if (m_eventEmitter) {

--- a/harmony/smart_refresh_layout/src/main/cpp/SmartUtils.h
+++ b/harmony/smart_refresh_layout/src/main/cpp/SmartUtils.h
@@ -8,10 +8,14 @@
 #define HARMONY_ANIMATION_H
 #include <string>
 #include <react/renderer/graphics/Color.h>
+#include <regex>
 
 class SmartUtils {
 public:
     static facebook::react::SharedColor parseColor(std::string backColor) {
+        if (backColor != "" && backColor.find("rgb") != std::string::npos) {
+            return parseRgbOrRgba(backColor);
+        }
         if (backColor != "" && backColor.find("#") != std::string::npos) {
             backColor = backColor.substr(1);
         }
@@ -30,7 +34,27 @@ public:
         }
         return facebook::react::colorFromComponents({red, green, blue, alpha});
     }
-    
+
+    static facebook::react::SharedColor parseRgbOrRgba(const std::string &colorStr) {
+        std::regex colorRegex(R"(rgb(a)?\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([01]|0\.\d+|1\.0*)\s*)?\))");
+        std::smatch matchResult;
+        if (!std::regex_match(colorStr, matchResult, colorRegex)) {
+            return -1;
+        }
+        float r = std::stoi(matchResult[2]) / 255.0;
+        float g = std::stoi(matchResult[3]) / 255.0;
+        float b = std::stoi(matchResult[4]) / 255.0;
+        float a = 1.0f;
+        if (matchResult[1].matched) {
+            if (matchResult[5].matched) {
+                a = std::stof(matchResult[5]);
+            } else {
+                return -1;
+            }
+        }
+       return facebook::react::colorFromComponents({r, g, b, a});
+    }
+
     // NOTE: ArkUI translation is in `px` units, while React Native uses `vp`
     static double vp2px(double pointScaleFactor, double value) { return pointScaleFactor * value; }
 };


### PR DESCRIPTION
# Summary

- fix:修复不支持“rgba的传值写法及其头部自己设置的背景颜色不起作用
- Closed: #69 




## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
